### PR TITLE
Fix issue #53 (undescriptive text for link in Multipass docs)

### DIFF
--- a/multipass/how-to/get_started_with_multipas_linux.md
+++ b/multipass/how-to/get_started_with_multipas_linux.md
@@ -1,0 +1,272 @@
+# Get started with Multipass - Linux
+
+Multipass is a flexible, powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. Used to a fuller extent, Multipass is a local mini-cloud on your laptop, allowing the testing and development of multi-instance or container-based cloud applications.
+
+This tutorial will give you an understanding of how Multipass works, and the skills you need to use its main features.
+
+## Contents
+
+- [Install Multipass](#heading--install-multipass)
+- [Create and use a basic instance](#heading--create-and-use-a-basic-instance)
+- [Create a customised instance](#heading--create-a-customised-instance)
+- [Manage instances](#heading--manage-instances)
+- [Put your instances to use](#heading--put-your-instances-to-use)
+  - [Run a simple web server](#heading--run-a-simple-web-server)
+  - [Launch from a Blueprint to run Docker containers](#heading--launch-from-a-blueprint-to-run-docker-containers)
+- [Next steps](#heading--next-steps)
+
+<a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
+
+Multipass is available for Linux, macOS, or Windows. To install it on your OS of choice, please follow the instructions given [how-to guides](https://multipass.run/docs/how-to-guides). Note: This tutorial demonstrates use on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+
+<a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
+
+<!--
+The easiest way to use Multipass is with the primary instance.
+Linux,
+The primary instance is a Multipass virtual machine that is configured to be useful for generic purposes out of the box.
+
+The primary instance automatically mounts the $HOME directory (files in this directory are shared between the host and the instance), and it comes with Multipass’s default specs: 1GB of RAM, 5GB of disk, and 1 CPU.
+-->
+
+From the application launcher, let's start Multipass. In Ubuntu, press the super key and type Multipass, or find Multipass in the Applications panel in the lower left of the desktop.
+
+![|800x450](https://assets.ubuntu.com/v1/949aa05e-mp-linux-1.png)
+
+Once we’ve launched the application, we should see the Multipass tray icon in the upper right section of the screen:
+
+![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png)
+
+Let's click on the icon, then on “Open Shell”.
+
+![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png)
+
+Clicking this button does many things in the background: it creates a new virtual machine (instance), named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU; installs the most recent Ubuntu LTS release on that instance; mounts our $HOME directory in the instance; and opens a shell to the instance, announced by the command prompt `ubuntu@primary`. You can see elements of this in the printout below.
+
+```plain
+Launched: primary                                                               
+Mounted '/home/<user>' into 'primary:Home'                                       
+Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-57-generic x86_64)
+
+ * Documentation:  https://help.ubuntu.com
+ * Management:     https://landscape.canonical.com
+ * Support:        https://ubuntu.com/advantage
+
+  System information as of Thu Jan 26 08:06:22 PST 2023
+
+  System load:  0.0               Processes:             95
+  Usage of /:   30.2% of 4.67GB   Users logged in:       0
+  Memory usage: 21%               IPv4 address for ens3: 10.110.66.242
+  Swap usage:   0%
+
+ * Strictly confined Kubernetes makes edge and IoT secure. Learn how MicroK8s
+   just raised the bar for easy, resilient and secure K8s cluster deployment.
+
+   https://ubuntu.com/engage/secure-kubernetes-at-the-edge
+
+0 updates can be applied immediately.
+
+
+The list of available updates is more than a week old.
+To check for new updates run: sudo apt update
+
+ubuntu@primary:~$
+```
+
+Let's test it out! As we just learned, the previous step automatically mounted our $HOME directory in the instance. Let's use this to share data with our instance. More concretely, let’s create a new folder in our $HOME directory called Multipass_Files:
+
+![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png)
+
+As you can see, I've added a readme file in this shared folder. Let's check for the folder and read the file from our new instance:
+
+```plain
+ubuntu@primary:~$ cd ./Home/Multipass_Files/
+ubuntu@primary:~/Home/Multipass_Files$ cat README.md 
+## Shared Folder
+
+This folder could be a great place to keep files that need to be accessed by both your host machine and Ubuntu VM!
+
+ubuntu@primary:~/Home/Multipass_Files$
+```
+
+Congratulations, you've got your first instance!
+
+This instance is great for when we just need a quick Ubuntu VM, but let’s say we want a more customised instance. Multipass has us covered there too!
+
+[details = "Optional Exercises"]
+Exercise 1:
+When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+
+Exercise 2:
+In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+[/details]
+
+<a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
+
+Multipass has a great feature to help us get started creating customised instances. Let’s open a terminal and run the command `multipass find`. This shows us a list of all of the images we can launch through Multipass currently.
+
+```plain
+$ multipass find
+Image                       Aliases           Version          Description
+snapcraft:core18            18.04             20201111         Snapcraft builder for Core 18
+snapcraft:core20            20.04             20210921         Snapcraft builder for Core 20
+snapcraft:core22            22.04             20220426         Snapcraft builder for Core 22
+snapcraft:devel                               20230126         Snapcraft builder for the devel series
+core                        core16            20200818         Ubuntu Core 16
+core18                                        20211124         Ubuntu Core 18
+core20                                        20230119         Ubuntu Core 20
+core22                                        20230119         Ubuntu Core 22
+18.04                       bionic            20230112         Ubuntu 18.04 LTS
+20.04                       focal             20230117         Ubuntu 20.04 LTS
+22.04                       jammy,lts         20230107         Ubuntu 22.04 LTS
+22.10                       kinetic           20230112         Ubuntu 22.10
+daily:23.04                 devel,lunar       20230125         Ubuntu 23.04
+appliance:adguard-home                        20200812         Ubuntu AdGuard Home Appliance
+appliance:mosquitto                           20200812         Ubuntu Mosquitto Appliance
+appliance:nextcloud                           20200812         Ubuntu Nextcloud Appliance
+appliance:openhab                             20200812         Ubuntu openHAB Home Appliance
+appliance:plexmediaserver                     20200812         Ubuntu Plex Media Server Appliance
+anbox-cloud-appliance                         latest           Anbox Cloud Appliance
+charm-dev                                     latest           A development and testing environment for charmers
+docker                                        0.4              A Docker environment with Portainer and related tools
+jellyfin                                      latest           Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media.
+minikube                                      latest           minikube is local Kubernetes
+```
+
+Let’s launch an instance running Ubuntu 22.10 (“Kinetic Kudu”) by typing the command `multipass launch kinetic`
+
+Now we have an instance running which has been named randomly by Multipass, in my case it is called coherent-trumpetfish.
+
+```plain
+$ multipass launch kinetic
+Launched: coherent-trumpetfish
+```
+
+We can check some basic info about our new instance by running the following:
+
+`multipass exec coherent-trumpetfish -- lsb_release -a`
+
+This tells multipass to execute the command `lsb_release -a` on the “coherent-trumpetfish” instance.
+
+```plain
+$ multipass exec coherent-trumpetfish -- lsb_release -a
+No LSB modules are available.
+Distributor ID: Ubuntu
+Description: Ubuntu 22.10
+Release:  22.10
+Codename:  kinetic
+```
+
+Perhaps after using this instance for a while, we decide what we really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. We can delete the coherent-trumpetfish instance by running
+
+`multipass delete coherent-trumpetfish`
+
+Let’s now launch the type of instance we’re looking for by running this:
+
+`multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
+
+<a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
+
+Now let’s confirm this new instance has the specs we’re looking for by running `multipass info ltsInstance`
+
+```plain
+$ multipass info ltsInstance                             
+Name:           ltsInstance
+State:          Running
+IPv4:           10.110.66.139
+Release:        Ubuntu 22.04.1 LTS
+Image hash:     3100a27357a0 (Ubuntu 22.04 LTS)
+CPU(s):         2
+Load:           1.11 0.36 0.12
+Disk usage:     1.4GiB out of 9.5GiB
+Memory usage:   170.4MiB out of 1.9GiB
+Mounts:         --
+```
+
+We’ve created and deleted quite a few instances now. Let’s run multipass list to see what instances we currently have.
+
+```plain
+$ multipass list                                         
+Name                    State             IPv4             Image
+primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
+coherent-trumpetfish    Deleted           --               Not Available
+ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
+```
+
+We have two instances currently running, the primary instance and our LTS machine with customised specs. Our "coherent-trumpetfish" instance is still listed, but its state is “Deleted”. We can recover this instance by running `multipass recover coherent-trumpetfish`, but for right now let’s delete the instance permanently by running `multipass purge`. Running `multipass list` again confirms the instance is now permanently deleted:
+
+```plain
+$ multipass list
+Name                    State             IPv4             Image
+primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
+ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
+```
+
+We’ve now seen a few ways to create, customise, and delete an instance. Now let’s put those instances to work!
+
+<a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
+
+<a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
+
+Let’s go back to that customised LTS instance we created. Take note of its IP address revealed by `multipass list` in the previous step, then run `multipass shell ltsInstance` to open a shell in the instance.
+
+From the shell, we can now run:
+
+```
+sudo apt update
+
+sudo apt install apache2
+```
+
+Now, let’s open a browser and type in the IP address of the instance in the address bar. We should now see the default Apache homepage.
+
+![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-linux-4.png)
+
+Just like that, we’ve got a web server running in a Multipass instance!
+
+We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+
+<a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
+
+Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. The Docker Blueprint, for example, is a pre-configured Docker environment with a Portainer container already running. We can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`
+
+Once that’s finished, let’s run `multipass info docker-dev` to note down the IP of the new instance.
+
+```plain
+$ multipass launch docker --name docker-dev
+Launched: docker-dev
+$ multipass info docker-dev
+Name:           docker-dev
+State:          Running
+IPv4:           10.115.5.235
+                172.17.0.1
+Release:        Ubuntu 22.04.1 LTS
+Image hash:     3100a27357a0 (Ubuntu 22.04 LTS)
+CPU(s):         2
+Load:           1.50 2.21 1.36
+Disk usage:     2.6GiB out of 38.6GiB
+Memory usage:   259.7MiB out of 3.8GiB
+Mounts:         --
+```
+
+Let’s take the IP address starting with “10” and paste it into our browser, then add a colon and the portainer default port, 9000, like this: 10.115.5.235:9000. This will take us to the Portainer login page, where we can set a username and password.
+
+![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-linux-5.png)
+
+From there, let’s select a local docker environment.
+
+![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-linux-6.png)
+
+From there, we can click into the newly created “local” docker endpoint, navigate to the app templates page, and select NGINX
+
+![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png)
+
+From the Portainer dashboard, we can see the ports that nginx has available. We can navigate to the IP address of our instance followed by that port number to see that we indeed have nginx running in a docker container inside Multipass!
+
+![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-linux-8.png)
+
+<a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
+
+Congratulations! You now have the skills you need to use Multipass proficiently. There’s more to learn about Multipass and its capabilities - check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and for help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options and more.
+
+Let us know what you’re able to get done with Multipass!

--- a/multipass/how-to/get_started_with_multipas_linux.md
+++ b/multipass/how-to/get_started_with_multipas_linux.md
@@ -17,7 +17,7 @@ This tutorial will give you an understanding of how Multipass works, and the ski
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOS, or Windows. To install it on your OS of choice, please follow the instructions given [how-to guides](https://multipass.run/docs/how-to-guides). Note: This tutorial demonstrates use on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+Multipass is available for Linux, macOS, or Windows. To install it on your OS of choice, please follow the instructions given in the [how-to guides](https://multipass.run/docs/how-to-guides). Note: This tutorial demonstrates use on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
 
@@ -98,7 +98,7 @@ Exercise 1:
 When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2:
-In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of a multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
@@ -135,7 +135,7 @@ minikube                                      latest           minikube is local
 
 Let’s launch an instance running Ubuntu 22.10 (“Kinetic Kudu”) by typing the command `multipass launch kinetic`
 
-Now we have an instance running which has been named randomly by Multipass, in my case it is called coherent-trumpetfish.
+Now we have an instance running that has been named randomly by Multipass; in my case, it is called coherent-trumpetfish.
 
 ```plain
 $ multipass launch kinetic
@@ -183,7 +183,7 @@ Memory usage:   170.4MiB out of 1.9GiB
 Mounts:         --
 ```
 
-We’ve created and deleted quite a few instances now. Let’s run multipass list to see what instances we currently have.
+We’ve created and deleted quite a few instances now. Let’s run a multipass list to see what instances we currently have.
 
 ```plain
 $ multipass list                                         
@@ -224,7 +224,7 @@ Now, let’s open a browser and type in the IP address of the instance in the ad
 
 Just like that, we’ve got a web server running in a Multipass instance!
 
-We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+We can use this web server locally for any kind of local development or testing we like. If, however, we want to access this web server from the internet (e.g., from a different computer), we need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 

--- a/multipass/how-to/how_to_install_multipass_on_macos.md
+++ b/multipass/how-to/how_to_install_multipass_on_macos.md
@@ -14,7 +14,7 @@
 
 <!--### Hypervisor.framework / hyperkit-->
 
-The default backend on macOS is `qemu`, wrapping Apple's Hypervisor.framework. You can use any Mac (M1, M2, or Intel based) with _macOS 10.15 Catalina_ or later installed.
+The default backend on macOS is `qemu`, wrapping Apple's Hypervisor framework. You can use any Mac (M1, M2, or Intel based) with _macOS 10.15 Catalina_ or later installed.
 
 <a href="#heading--install-upgrade-uninstall"><h2 id="heading--install-upgrade-uninstall">Install, upgrade, uninstall</h2></a>
 

--- a/multipass/how-to/how_to_install_multipass_on_macos.md
+++ b/multipass/how-to/how_to_install_multipass_on_macos.md
@@ -1,0 +1,121 @@
+# How to install Multipass on macOS
+
+> See also: [How to use VirtualBox in Multipass on macOS](/t/16591), [How to use a different terminal on macOS](/t/14955)
+
+**Contents:**
+
+- [Check prerequisites](#heading--check-prerequisites)
+- [Install, upgrade, uninstall](#heading--install-upgrade-uninstall)
+  - [Using the installer package](#heading--use-the-installer-package)
+  - [Using `brew`](#heading--use-brew)
+- [Run](#heading--run)
+
+<a href="#heading--check-prerequisites"><h2 id="heading--check-prerequisites">Check prerequisites</h2></a>
+
+<!--### Hypervisor.framework / hyperkit-->
+
+The default backend on macOS is `qemu`, wrapping Apple's Hypervisor.framework. You can use any Mac (M1, M2, or Intel based) with _macOS 10.15 Catalina_ or later installed.
+
+<a href="#heading--install-upgrade-uninstall"><h2 id="heading--install-upgrade-uninstall">Install, upgrade, uninstall</h2></a>
+
+To install Multipass on macOS, you have two options: the installer package or [`brew`](https://brew.sh/). Upgrading and uninstallation options depend on this choice as well.
+
+<a href="#heading--use-the-installer-package"><h3 id="heading--use-the-installer-package">Using the installer package</h3></a>
+
+Download the latest installer from [our download page](https://multipass.run/download/macos). You can also get pre-release versions from [our GitHub releases page](https://github.com/canonical/multipass/releases/) - it's the `.pkg` package.
+
+If you want Tab completion on the command line, install [`bash-completion@2` from `brew`](https://formulae.brew.sh/formula/bash-completion@2) and follow these [instructions](https://docs.brew.sh/Shell-Completion) on updating your `.bashrc` file.
+
+Activate the downloaded installer and it will guide you through the necessary steps. You will need an account with administrator privileges to complete the installation.
+
+![Multipass installer on macOS|658x475](upload://oBqM17GtMd6dzpBJ2OWl3fexIP2.png)
+
+To uninstall, run the script:
+
+```plain
+sudo sh "/Library/Application Support/com.canonical.multipass/uninstall.sh"
+```
+
+<a href="#heading--use-brew"><h3 id="heading--use-brew">Using `brew`</h3></a>
+
+If you don't have it already, [install Brew](https://brew.sh/). Then, to install Multipass simply execute:
+
+```plain
+brew install multipass
+```
+
+To uninstall while keeping your VMs and data, you can use:
+
+```plain
+brew uninstall multipass
+```
+
+[note type="caution"]
+*_Caveats:_
+
+Although Brew supports the `--zap` option to remove all data, it does not allow Multipass to remove all the VMs and data properly. The Multipass daemon needs to be alive and running to unregister VMs from certain backends (e.g. VirtualBox). However, Brew executes the zap procedure strictly after the uninstall step. By then, the Multipass daemon is no longer available.
+
+[This issue report](https://github.com/Homebrew/homebrew-cask/issues/85498) has more information. The workaround is to remove VMs manually _before_ uninstalling:
+
+1. `multipass delete --purge --all`  
+2. `brew uninstall --zap multipass # to destroy all other data, too`
+[/note]
+
+<a href="#heading--run"><h2 id="heading--run">Run</h2></a>
+
+You’ve installed Multipass. Time to run your first commands! Use `multipass version` to check your version or `multipass launch` to create your first instance.
+
+<!--PREVIOUS DRAFT:
+## Prerequisites
+
+### Hypervisor.framework / hyperkit
+
+The default backend on macOS is `hyperkit` on Intel, and `qemu` on the M1, wrapping Apple's Hypervisor.framework. You can use any M1 Mac, or a _2010_ or newer Intel Mac with _macOS 10.14 Mojave_ or later installed.
+
+## Installation
+
+To install Multipass on macOS, you have two options: the installer package or [`brew`](https://brew.sh/):
+
+### Installer
+
+Download the latest installer from [our GitHub releases page](https://github.com/CanonicalLtd/multipass/releases/) - it's the `.pkg` package.
+
+If you want Tab completion on the command line, install [`bash-completion` from `brew`](https://formulae.brew.sh/formula/bash-completion) first.
+
+Activate the downloaded installer and it will guide you through the steps necessary. You will need an account with Administrator privileges to complete the installation.
+
+![Multipass installer on macOS|658x475](upload://oBqM17GtMd6dzpBJ2OWl3fexIP2.png)
+
+There's a script to uninstall:
+```plain
+$ sudo sh "/Library/Application Support/com.canonical.multipass/uninstall.sh"
+```
+
+### Brew
+Have a look at [`brew.sh`](https://brew.sh/) on instructions to install Brew itself. Then, it's a simple:
+```plain
+$ brew install --cask multipass
+```
+
+To uninstall:
+```plain
+$ brew uninstall multipass
+# or, to destroy all data
+$ brew uninstall --zap multipass
+```
+
+## First run
+
+Once installed, open the **Terminal** app and you can use `multipass launch` to create your first instance.
+
+With `multipass version` you can check which version you have running:
+
+```plain
+$ multipass version
+multipass 1.9.0+mac
+multipassd 1.9.0+mac
+```
+
+Have a look at [Working with instances](/t/working-with-multipass-instances/8422) to quickly get off the ground!
+
+-->

--- a/multipass/how-to/how_to_install_multipass_on_windows.md
+++ b/multipass/how-to/how_to_install_multipass_on_windows.md
@@ -1,0 +1,92 @@
+# How to install Multipass on Windows
+
+> See also: [How to use Virtualbox in Multipass on Windows](/t/16626)
+
+**Contents:**
+
+- [Check prerequisites](#heading--check-prerequisites)
+  - [Hyper-V](#heading--hyper-v)
+  - [VirtualBox](#heading--virtualbox)
+- [Install, upgrade, uninstall](#heading--install-upgrade-uninstall)
+- [Run](#heading--run)
+
+<a href="#heading--check-prerequisites"><h2 id="heading--check-prerequisites">Check prerequisites</h2></a>
+
+<a href="#heading--hyper-v"><h3 id="heading--hyper-v">Hyper-V</h3></a>
+
+Only **Windows 10 Pro** or **Enterprise**, version **1803** ("April 2018 Update") or later is currently supported. It's due to the necessary version of Hyper-V only being available on those versions.
+
+<a href="#heading--virtualbox"><h3 id="heading--virtualbox">VirtualBox</h3></a>
+
+Multipass also supports using VirtualBox as a virtualization provider.  You can download the latest version from [VirtualBox download page](https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html).
+
+<a href="#heading--install-upgrade-uninstall"><h2 id="heading--install-upgrade-uninstall">Install, upgrade, uninstall</h2></a>
+
+Download the latest installer from [here](https://multipass.run/download/windows). You can also get pre-release versions from [our GitHub releases page](https://github.com/CanonicalLtd/multipass/releases/) - it's the `.exe` file. Run the installer and it will guide you through the steps necessary. You will need to allow the installer to gain Administrator privileges.
+
+You will need either Hyper-V enabled (only Windows 10 Professional or Enterprise), or VirtualBox installed.
+
+To upgrade, just [download the latest installer](https://multipass.run/download/windows) and run it.
+
+You will be asked to uninstall the old version, and a second question about whether to remove all data when uninstalling. If you want to _keep your instances_, answer "No" (the default).
+
+<a href="#heading--run"><h2 id="heading--run">Run</h2></a>
+
+Now, to run normal Multipass commands, open either **Command Prompt** (`cmd.exe`) or **PowerShell** as a regular user.  Use `multipass version` to check your version or `multipass launch` to create your first instance.
+
+Multipass defaults to using Hyper-V as its virtualization provider.  If you'd like to use VirtualBox, you can do so with:
+
+```
+multipass set local.driver=virtualbox
+```
+
+<!--PREVIOUS DRAFT:
+
+## Downloading
+
+To get Multipass for Windows, download the latest installer from [our GitHub releases page](https://github.com/CanonicalLtd/multipass/releases/) - it's the `.exe` file.
+
+## Prerequisites
+
+### Hyper-V
+
+Only **Windows 10 Pro** or **Enterprise**, version **1803** ("April 2018 Update") or later is currently supported. It's due to the right version of Hyper-V only being available on those versions.
+
+### VirtualBox
+
+Multipass also supports using VirtualBox as a virtualization provider.  You can download the latest version [here](https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html).
+
+## Installation
+
+Make sure the network you're connected to is marked *Private* (which really means *Trusted*), otherwise Windows will prevent Multipass from starting. We're working on resolving that issue.
+
+Run the installer and it will guide you through the steps necessary. You will need to allow the installer to gain Administrator privileges.
+
+You will need either Hyper-V enabled (only Windows 10 Professional or Enterprise), or VirtualBox installed.
+
+## First run
+
+Multipass defaults to using Hyper-V as its virtualization provider.  If you'd like to use VirtualBox, start either **Command Prompt** (`cmd.exe`) or **PowerShell** as `Administrator` and run:
+```
+C:\WINDOWS\system32> multipass set local.driver=virtualbox
+```
+
+Now, to run normal Multipass commands, open either **Command Prompt** (`cmd.exe`) or **PowerShell** as your regular user and you can use `multipass launch` to create your first instance.
+
+With `multipass version` you can check which version you have running:
+
+```plain
+$ multipass version
+multipass  v1.0.0+win
+multipassd v1.0.0+win
+```
+
+Have a look at [Working with instances](/t/working-with-multipass-instances/8422) for a rundown of the most common steps. We hope you have fun!
+
+## Upgrading<a name="upgrading"></a>
+
+To upgrade, just [download the latest installer](https://multipass.run/download/windows) and run it. 
+
+You will be asked to uninstall the old version, and a second question about whether to remove all data when uninstalling. If you want to _keep your instances_, answer "No" (the default).
+
+-->


### PR DESCRIPTION
I tried using the keyword "here" in Multipass docs and replaced it with descriptive words. I also made some minor edits (e.g., macOS --> macOS).

Let me know if there are pages that need to be edited regarding this PR.

@rkratky 