### PR TITLE
Improve language in multipass/Linux.md

### DIFF
--- a/multipass/Linux.md
+++ b/multipass/Linux.md
@@ -1,8 +1,8 @@
 nhart | 2023-12-07 11:18:47 UTC | #1
 
-Multipass is a flexible, powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. Used to a fuller extent, Multipass is a local mini-cloud on your laptop, allowing the testing and development of multi-instance or container-based cloud applications.
+Multipass is a flexible and powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. When used maximally, Multipass is a local mini-cloud on your laptop, ensuring that you can test and develop multi-instance or container-based cloud applications.
 
-This tutorial will give you an understanding of how Multipass works, and the skills you need to use its main features.
+This tutorial will help you understand how Multipass works, and the skills you need to use its main features.
 
 
 ## Contents
@@ -18,7 +18,7 @@ This tutorial will give you an understanding of how Multipass works, and the ski
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, or Windows. To install it on your OS of choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). Note: This tutorial demonstrates use on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
@@ -30,20 +30,20 @@ The primary instance is a Multipass virtual machine that is configured to be use
 
 The primary instance automatically mounts the $HOME directory (files in this directory are shared between the host and the instance), and it comes with Multipass's default specs: 1GB of RAM, 5GB of disk, and 1 CPU.
 -->
-
-From the application launcher, let's start Multipass. In Ubuntu, press the super key and type Multipass, or find Multipass in the Applications panel in the lower left of the desktop.
+Start Multipass from the application launcher. In Ubuntu, press the super key and type "Multipass", or find Multipass in the Applications panel on the lower left of the desktop.
 
 ![|800x450](https://assets.ubuntu.com/v1/949aa05e-mp-linux-1.png) 
 
-Once we've launched the application, we should see the Multipass tray icon in the upper right section of the screen:
+Once you've launched the application, you should see the Multipass tray icon on the upper right section of the screen:
 
 ![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png) 
 
-Let's click on the icon, then on "Open Shell". 
+Click on the icon, then click on "Open Shell". 
 
 ![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png) 
 
-Clicking this button does many things in the background: it creates a new virtual machine (instance), named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU; installs the most recent Ubuntu LTS release on that instance; mounts our $HOME directory in the instance; and opens a shell to the instance, announced by the command prompt `ubuntu@primary`. You can see elements of this in the printout below.
+Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your $HOME directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+You can see elements of this in the printout below:
 
 ```plain
 Launched: primary                                                               
@@ -75,11 +75,11 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let's test it out! As we just learned, the previous step automatically mounted our $HOME directory in the instance. Let's use this to share data with our instance. More concretely, let's create a new folder in our $HOME directory called Multipass_Files:
+Test it out. As you've just learnt, the previous step automatically mounted your $HOME directory in the instance. Use this to share data with your instance. More concretely, create a new folder called Multipass_Files in your $HOME directory:
 
 ![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png) 
 
-As you can see, I've added a readme file in this shared folder. Let's check for the folder and read the file from our new instance:
+As you can see, a readme file has been added in this shared folder. Check for the folder and read the file from your new instance:
 
 ```plain
 ubuntu@primary:~$ cd ./Home/Multipass_Files/
@@ -93,19 +93,19 @@ ubuntu@primary:~/Home/Multipass_Files$
 
 Congratulations, you've got your first instance! 
 
-This instance is great for when we just need a quick Ubuntu VM, but let's say we want a more customised instance. Multipass has us covered there too!
+This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance. Multipass has you covered there too.
 
 [details = "Optional Exercises"]
 Exercise 1: 
-When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+When you click on Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name `primary` is privileged. That is, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help us get started creating customised instances. Let's open a terminal and run the command `multipass find`. This shows us a list of all of the images we can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the command `multipass find`. This shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 $ multipass find
@@ -135,16 +135,16 @@ jellyfin                                      latest           Jellyfin is a Fre
 minikube                                      latest           minikube is local Kubernetes
 ```
 
-Let's launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the command `multipass launch kinetic`
+Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the command `multipass launch kinetic`.
 
-Now we have an instance running which has been named randomly by Multipass, in my case it is called "coherent-trumpetfish".
+Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "coherent-trumpetfish".
 
 ```plain
 $ multipass launch kinetic
 Launched: coherent-trumpetfish
 ```
 
-We can check some basic info about our new instance by running the following:
+You can check some basic info about your new instance by running the following:
 
 `multipass exec coherent-trumpetfish -- lsb_release -a`
 
@@ -159,17 +159,17 @@ Release:		22.10
 Codename:		kinetic
 ```
 
-Perhaps after using this instance for a while, we decide what we really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. We can delete the "coherent-trumpetfish" instance by running
+Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "coherent-trumpetfish" instance by running
 
 `multipass delete coherent-trumpetfish`
 
-Let's now launch the type of instance we're looking for by running this:
+You can now launch the type of instance you need by running this:
 
 `multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-Now let's confirm this new instance has the specs we're looking for by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
 
 ```plain
 $ multipass info ltsInstance                             
@@ -185,7 +185,7 @@ Memory usage:   170.4MiB out of 1.9GiB
 Mounts:         --
 ```
 
-We've created and deleted quite a few instances now. Let's run multipass list to see what instances we currently have.
+You've created and deleted quite a few instances. Now, run `multipass list` to see the instances you currently have.
 
 ```plain
 $ multipass list                                         
@@ -195,7 +195,7 @@ coherent-trumpetfish    Deleted           --               Not Available
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-We have two instances currently running, the primary instance and our LTS machine with customised specs. Our "coherent-trumpetfish" instance is still listed, but its state is "Deleted". We can recover this instance by running `multipass recover coherent-trumpetfish`, but for right now let's delete the instance permanently by running `multipass purge`. Running `multipass list` again confirms the instance is now permanently deleted: 
+You have two instances running, the primary instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted: 
 
 ```plain
 $ multipass list
@@ -204,15 +204,15 @@ primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-We've now seen a few ways to create, customise, and delete an instance. Now let's put those instances to work!
+You've seen a few ways to create, customise, and delete an instance. Now put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
 
 <a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
 
-Let's go back to that customised LTS instance we created. Take note of its IP address revealed by `multipass list` in the previous step, then run `multipass shell ltsInstance` to open a shell in the instance.
+Return to your customised LTS instance. Take note of its IP address, which was revealed when you ran `multipass list`. Then run `multipass shell ltsInstance` to open a shell in the instance.
 
-From the shell, we can now run:
+From the shell, you can run:
 
 ```
 sudo apt update
@@ -220,19 +220,19 @@ sudo apt update
 sudo apt install apache2
 ```
 
-Now, let's open a browser and type in the IP address of the instance into the address bar. We should now see the default Apache homepage.
+Open a browser and type in the IP address of your instance into the address bar. You should now see the default Apache homepage.
 
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-linux-4.png) 
 
-Just like that, we've got a web server running in a Multipass instance!
+Just like that, you've got a web server running in a Multipass instance!
 
-We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (For instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
-Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. The Docker Blueprint, for example, is a pre-configured Docker environment with a Portainer container already running. We can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`
+Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. For example, the Docker Blueprint is a pre-configured Docker environment with a Portainer container already running. You can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`.
 
-Once that's finished, let's run `multipass info docker-dev` to note down the IP of the new instance.
+Once that's done, run `multipass info docker-dev` to note down the IP of the new instance.
 
 ```plain
 $ multipass launch docker --name docker-dev
@@ -251,25 +251,25 @@ Memory usage:   259.7MiB out of 3.8GiB
 Mounts:         --
 ```
 
-Let's take the IP address starting with "10" and paste it into our browser, then add a colon and the portainer default port, 9000, like this: 10.115.5.235:9000. This will take us to the Portainer login page, where we can set a username and password.
+Copy the IP address starting with "10" and paste it into your browser, then add a colon and the portainer default port, 9000. It should look like this: 10.115.5.235:9000. This will take you to the Portainer login page where you can set a username and password.
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-linux-5.png) 
 
-From there, let's select a local docker environment.
+From there, select a local docker environment.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-linux-6.png) 
 
-From there, we can click into the newly created "local" docker endpoint, navigate to the app templates page, and select NGINX
+Inside the newly selected local docker environment, navigate to the table of content, click on "app templates", and select NGINX.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png) 
 
-From the Portainer dashboard, we can see the ports that nginx has available. We can navigate to the IP address of our instance followed by that port number to see that we indeed have nginx running in a docker container inside Multipass!
+From the Portainer dashboard, you can see the ports available on nginx. You can navigate to the IP address of your instance, followed by the port number to see that you indeed have nginx running in a docker container inside Multipass.
 
 ![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-linux-8.png) 
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You now have the skills you need to use Multipass proficiently. There's more to learn about Multipass and its capabilities - check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and for help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you're able to get done with Multipass!
 


### PR DESCRIPTION
Did things like (#55 ): made sentences more concise, aligned writing with canonical documentation guideline by ensuring that words and phrases that should be avoided are avoided - pronouns are used right and consistently - and words are British instead of American, corrected grammatical errrors by using words (like the word <now>, spotting when it is used as an adverb and when it is not) and punctuations properly, and re-wrote confusing sentences.

Will work on Windows and macOS. Wanted to push this and get response on whether it is being done right