### PR TITLE
Improve language in multipass/Linux.md

### DIFF
--- a/multipass/Linux.md
+++ b/multipass/Linux.md
@@ -18,8 +18,9 @@ This tutorial will help you understand how Multipass works, and the skills you n
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
 
+Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
 
@@ -34,7 +35,7 @@ Start Multipass from the application launcher. In Ubuntu, press the super key an
 
 ![|800x450](https://assets.ubuntu.com/v1/949aa05e-mp-linux-1.png) 
 
-Once you've launched the application, you should see the Multipass tray icon on the upper right section of the screen:
+Once you've launched the application, you should see the Multipass tray icon on the upper right section of the screen.
 
 ![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png) 
 
@@ -43,6 +44,7 @@ Click on the **icon**, then select **Open Shell**.
 ![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png) 
 
 Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named "primary", with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your `$HOME` directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+
 You can see elements of this in the printout below:
 
 ```plain
@@ -75,7 +77,7 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let's test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Use this to share data with your instance. More concretely, create a new folder called `Multipass_Files` in your `$HOME` directory:
+Let's test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Use this to share data with your instance. More concretely, create a new folder called `Multipass_Files` in your `$HOME` directory.
 
 ![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png) 
 
@@ -100,12 +102,12 @@ Exercise 1:
 When you select Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name "primary" is privileged. That is, it serves as the default argument of `multipass shell` among other capabilities. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name "primary" is privileged. That is, it serves as the default argument of `multipass shell` among other capabilities. In different terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the command `multipass find`. The result shows a list of all of the images you can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 $ multipass find
@@ -135,7 +137,7 @@ jellyfin                                      latest           Jellyfin is a Fre
 minikube                                      latest           minikube is local Kubernetes
 ```
 
-Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the command `multipass launch kinetic`.
+Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the `multipass launch kinetic` command.
 
 Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "coherent-trumpetfish".
 
@@ -195,7 +197,7 @@ coherent-trumpetfish    Deleted           --               Not Available
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-The result shows that you have two instances running, the "primary" instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted: 
+The result shows that you have two instances running, the "primary" instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted. 
 
 ```plain
 $ multipass list
@@ -207,6 +209,8 @@ ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 You've now seen a few ways to create, customise, and delete an instance. It is time to put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
+
+One way to put a Multipass instance to use is by running a local or web server in it.
 
 <a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
 
@@ -263,7 +267,7 @@ Inside the newly selected local Docker environment, navigate to the **table of c
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png) 
 
-From the Portainer dashboard, you can see the ports available on nginx. To verify that you have nginx running in a Docker container inside Multipass, open a web browser and paste the IP address of your instance followed by one of the port numbers.
+From the Portainer dashboard, you can see the ports available on nginx. To verify that you have nginx running in a Docker container inside Multipass, open a new web page and paste the IP address of your instance followed by one of the port numbers.
 
 ![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-linux-8.png) 
 

--- a/multipass/Linux.md
+++ b/multipass/Linux.md
@@ -1,8 +1,8 @@
 nhart | 2023-12-07 11:18:47 UTC | #1
 
-Multipass is a flexible, powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. Used to a fuller extent, Multipass is a local mini-cloud on your laptop, allowing the testing and development of multi-instance or container-based cloud applications.
+Multipass is a flexible and powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. When used maximally, Multipass is a local mini-cloud on your laptop, ensuring that you can test and develop multi-instance or container-based cloud applications.
 
-This tutorial will give you an understanding of how Multipass works, and the skills you need to use its main features.
+This tutorial will help you understand how Multipass works, and the skills you need to use its main features.
 
 
 ## Contents
@@ -18,7 +18,7 @@ This tutorial will give you an understanding of how Multipass works, and the ski
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, or Windows. To install it on your OS of choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). Note: This tutorial demonstrates use on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
@@ -30,20 +30,20 @@ The primary instance is a Multipass virtual machine that is configured to be use
 
 The primary instance automatically mounts the $HOME directory (files in this directory are shared between the host and the instance), and it comes with Multipass's default specs: 1GB of RAM, 5GB of disk, and 1 CPU.
 -->
-
-From the application launcher, let's start Multipass. In Ubuntu, press the super key and type Multipass, or find Multipass in the Applications panel in the lower left of the desktop.
+Start Multipass from the application launcher. In Ubuntu, press the super key and type "Multipass", or find Multipass in the Applications panel on the lower left of the desktop.
 
 ![|800x450](https://assets.ubuntu.com/v1/949aa05e-mp-linux-1.png) 
 
-Once we've launched the application, we should see the Multipass tray icon in the upper right section of the screen:
+Once you've launched the application, you should see the Multipass tray icon on the upper right section of the screen:
 
 ![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png) 
 
-Let's click on the icon, then on "Open Shell". 
+Click on the icon, then click on "Open Shell". 
 
 ![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png) 
 
-Clicking this button does many things in the background: it creates a new virtual machine (instance), named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU; installs the most recent Ubuntu LTS release on that instance; mounts our $HOME directory in the instance; and opens a shell to the instance, announced by the command prompt `ubuntu@primary`. You can see elements of this in the printout below.
+Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your $HOME directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+You can see elements of this in the printout below:
 
 ```plain
 Launched: primary                                                               
@@ -75,11 +75,11 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let's test it out! As we just learned, the previous step automatically mounted our $HOME directory in the instance. Let's use this to share data with our instance. More concretely, let's create a new folder in our $HOME directory called Multipass_Files:
+Test it out. As you've just learnt, the previous step automatically mounted your $HOME directory in the instance. Use this to share data with your instance. More concretely, create a new folder called Multipass_Files in your $HOME directory:
 
 ![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png) 
 
-As you can see, I've added a readme file in this shared folder. Let's check for the folder and read the file from our new instance:
+As you can see, a readme file has been added in this shared folder. Check for the folder and read the file from your new instance:
 
 ```plain
 ubuntu@primary:~$ cd ./Home/Multipass_Files/
@@ -93,19 +93,19 @@ ubuntu@primary:~/Home/Multipass_Files$
 
 Congratulations, you've got your first instance! 
 
-This instance is great for when we just need a quick Ubuntu VM, but let's say we want a more customised instance. Multipass has us covered there too!
+This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance. Multipass has you covered there too.
 
 [details = "Optional Exercises"]
 Exercise 1: 
-When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+When you click on Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name `primary` is privileged. That is, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help us get started creating customised instances. Let's open a terminal and run the command `multipass find`. This shows us a list of all of the images we can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the command `multipass find`. This shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 $ multipass find
@@ -135,16 +135,16 @@ jellyfin                                      latest           Jellyfin is a Fre
 minikube                                      latest           minikube is local Kubernetes
 ```
 
-Let's launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the command `multipass launch kinetic`
+Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the command `multipass launch kinetic`.
 
-Now we have an instance running which has been named randomly by Multipass, in my case it is called "coherent-trumpetfish".
+Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "coherent-trumpetfish".
 
 ```plain
 $ multipass launch kinetic
 Launched: coherent-trumpetfish
 ```
 
-We can check some basic info about our new instance by running the following:
+You can check some basic info about your new instance by running the following:
 
 `multipass exec coherent-trumpetfish -- lsb_release -a`
 
@@ -159,17 +159,17 @@ Release:		22.10
 Codename:		kinetic
 ```
 
-Perhaps after using this instance for a while, we decide what we really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. We can delete the "coherent-trumpetfish" instance by running
+Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "coherent-trumpetfish" instance by running
 
 `multipass delete coherent-trumpetfish`
 
-Let's now launch the type of instance we're looking for by running this:
+You can now launch the type of instance you need by running this:
 
 `multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-Now let's confirm this new instance has the specs we're looking for by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
 
 ```plain
 $ multipass info ltsInstance                             
@@ -185,7 +185,7 @@ Memory usage:   170.4MiB out of 1.9GiB
 Mounts:         --
 ```
 
-We've created and deleted quite a few instances now. Let's run multipass list to see what instances we currently have.
+You've created and deleted quite a few instances. Now, run `multipass list` to see the instances you currently have.
 
 ```plain
 $ multipass list                                         
@@ -195,7 +195,7 @@ coherent-trumpetfish    Deleted           --               Not Available
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-We have two instances currently running, the primary instance and our LTS machine with customised specs. Our "coherent-trumpetfish" instance is still listed, but its state is "Deleted". We can recover this instance by running `multipass recover coherent-trumpetfish`, but for right now let's delete the instance permanently by running `multipass purge`. Running `multipass list` again confirms the instance is now permanently deleted: 
+You have two instances running, the primary instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted: 
 
 ```plain
 $ multipass list
@@ -204,15 +204,15 @@ primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-We've now seen a few ways to create, customise, and delete an instance. Now let's put those instances to work!
+You've seen a few ways to create, customise, and delete an instance. Now put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
 
 <a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
 
-Let's go back to that customised LTS instance we created. Take note of its IP address revealed by `multipass list` in the previous step, then run `multipass shell ltsInstance` to open a shell in the instance.
+Return to your customised LTS instance. Take note of its IP address, which was revealed when you ran `multipass list`. Then run `multipass shell ltsInstance` to open a shell in the instance.
 
-From the shell, we can now run:
+From the shell, you can run:
 
 ```
 sudo apt update
@@ -220,19 +220,19 @@ sudo apt update
 sudo apt install apache2
 ```
 
-Now, let's open a browser and type in the IP address of the instance into the address bar. We should now see the default Apache homepage.
+Open a browser and type in the IP address of your instance into the address bar. You should now see the default Apache homepage.
 
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-linux-4.png) 
 
-Just like that, we've got a web server running in a Multipass instance!
+Just like that, you've got a web server running in a Multipass instance!
 
-We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (For instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
-Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. The Docker Blueprint, for example, is a pre-configured Docker environment with a Portainer container already running. We can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`
+Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. For example, the Docker Blueprint is a pre-configured Docker environment with a Portainer container already running. You can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`.
 
-Once that's finished, let's run `multipass info docker-dev` to note down the IP of the new instance.
+Once that's done, run `multipass info docker-dev` to note down the IP of the new instance.
 
 ```plain
 $ multipass launch docker --name docker-dev
@@ -251,25 +251,25 @@ Memory usage:   259.7MiB out of 3.8GiB
 Mounts:         --
 ```
 
-Let's take the IP address starting with "10" and paste it into our browser, then add a colon and the portainer default port, 9000, like this: 10.115.5.235:9000. This will take us to the Portainer login page, where we can set a username and password.
+Copy the IP address starting with "10" and paste it into your browser, then add a colon and the portainer default port, 9000. It should look like this: 10.115.5.235:9000. This will take you to the Portainer login page where you can set a username and password.
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-linux-5.png) 
 
-From there, let's select a local docker environment.
+From there, select a local docker environment.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-linux-6.png) 
 
-From there, we can click into the newly created "local" docker endpoint, navigate to the app templates page, and select NGINX
+Inside the newly selected local docker environment, navigate to the table of content, click on "app templates", and select NGINX.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png) 
 
-From the Portainer dashboard, we can see the ports that nginx has available. We can navigate to the IP address of our instance followed by that port number to see that we indeed have nginx running in a docker container inside Multipass!
+From the Portainer dashboard, you can see the ports available on nginx. You can navigate to the IP address of your instance, followed by the port number to see that you indeed have nginx running in a docker container inside Multipass.
 
 ![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-linux-8.png) 
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You now have the skills you need to use Multipass proficiently. There's more to learn about Multipass and its capabilities - check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and for help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you're able to get done with Multipass!
 

--- a/multipass/Linux.md
+++ b/multipass/Linux.md
@@ -18,7 +18,7 @@ This tutorial will help you understand how Multipass works, and the skills you n
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
+Multipass is available for Linux, macOS and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
 
 Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
@@ -35,11 +35,11 @@ Start Multipass from the application launcher. In Ubuntu, press the super key an
 
 ![|800x450](https://assets.ubuntu.com/v1/949aa05e-mp-linux-1.png) 
 
-Once you've launched the application, you should see the Multipass tray icon on the upper right section of the screen.
+After launching the application, you should see the Multipass tray icon on the upper right section of the screen.
 
 ![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png) 
 
-Click on the **icon**, then select **Open Shell**. 
+Click on the Multipass icon and select **Open Shell**. 
 
 ![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png) 
 
@@ -81,7 +81,7 @@ Let's test it out. As you've just learnt, the previous step automatically mounte
 
 ![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png) 
 
-As you can see, a readme file has been added in this shared folder. Check for the folder and read the file from your new instance:
+As you can see, a `README.md` file has been added to the shared folder. Check for the folder and read the file from your new instance:
 
 ```plain
 ubuntu@primary:~$ cd ./Home/Multipass_Files/
@@ -107,7 +107,7 @@ In Multipass, an instance with the name "primary" is privileged. That is, it ser
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all images you can currently launch through Multipass.
 
 ```plain
 $ multipass find
@@ -171,7 +171,7 @@ You can now launch the type of instance you need by running this command:
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`.
 
 ```plain
 $ multipass info ltsInstance                             
@@ -230,7 +230,7 @@ Open a browser and type in the IP address of your instance into the address bar.
 
 Just like that, you've got a web server running in a Multipass instance!
 
-You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. However, if you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
@@ -259,11 +259,11 @@ Copy the IP address starting with "10" and paste it into your browser, then add 
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-linux-5.png) 
 
-From there, select **a local Docker environment**.
+From there, select **Local** to manage a local Docker environment.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-linux-6.png) 
 
-Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
+Inside the newly selected local Docker environment, locate the sidebar menu on the page and click on **app templates**, then select **NGINX**.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png) 
 
@@ -273,7 +273,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options and more.
 
 Let us know what you're able to get done with Multipass!
 

--- a/multipass/Linux.md
+++ b/multipass/Linux.md
@@ -18,7 +18,7 @@ This tutorial will help you understand how Multipass works, and the skills you n
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). Note that this tutorial demonstrates how to use Multipass on Linux, specifically Ubuntu, but the experience on any OS should be similar.
 
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
@@ -38,11 +38,11 @@ Once you've launched the application, you should see the Multipass tray icon on 
 
 ![|688x52](https://assets.ubuntu.com/v1/5ec546da-mp-linux-2.png) 
 
-Click on the icon, then click on "Open Shell". 
+Click on the **icon**, then select **Open Shell**. 
 
 ![|286x274](https://assets.ubuntu.com/v1/3ecc5e7d-mp-linux-2a.png) 
 
-Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your $HOME directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named "primary", with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your `$HOME` directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
 You can see elements of this in the printout below:
 
 ```plain
@@ -75,7 +75,7 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Test it out. As you've just learnt, the previous step automatically mounted your $HOME directory in the instance. Use this to share data with your instance. More concretely, create a new folder called Multipass_Files in your $HOME directory:
+Let's test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Use this to share data with your instance. More concretely, create a new folder called `Multipass_Files` in your `$HOME` directory:
 
 ![|720x405](https://assets.ubuntu.com/v1/fbfc8304-mp-linux-3.png) 
 
@@ -93,19 +93,19 @@ ubuntu@primary:~/Home/Multipass_Files$
 
 Congratulations, you've got your first instance! 
 
-This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance. Multipass has you covered there too.
+This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance, how can you do that? Multipass has you covered there too.
 
 [details = "Optional Exercises"]
 Exercise 1: 
-When you click on Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+When you select Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name `primary` is privileged. That is, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name "primary" is privileged. That is, it serves as the default argument of `multipass shell` among other capabilities. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the command `multipass find`. This shows a list of all of the images you can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the command `multipass find`. The result shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 $ multipass find
@@ -144,7 +144,7 @@ $ multipass launch kinetic
 Launched: coherent-trumpetfish
 ```
 
-You can check some basic info about your new instance by running the following:
+You can check some basic info about your new instance by running the following command:
 
 `multipass exec coherent-trumpetfish -- lsb_release -a`
 
@@ -159,11 +159,11 @@ Release:		22.10
 Codename:		kinetic
 ```
 
-Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "coherent-trumpetfish" instance by running
+Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "coherent-trumpetfish" instance by running the following command:
 
 `multipass delete coherent-trumpetfish`
 
-You can now launch the type of instance you need by running this:
+You can now launch the type of instance you need by running this command:
 
 `multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
 
@@ -185,7 +185,7 @@ Memory usage:   170.4MiB out of 1.9GiB
 Mounts:         --
 ```
 
-You've created and deleted quite a few instances. Now, run `multipass list` to see the instances you currently have.
+You've created and deleted quite a few instances. It is time to run `multipass list` to see the instances you currently have.
 
 ```plain
 $ multipass list                                         
@@ -195,7 +195,7 @@ coherent-trumpetfish    Deleted           --               Not Available
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-You have two instances running, the primary instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted: 
+The result shows that you have two instances running, the "primary" instance and the LTS machine with customised specs. The "coherent-trumpetfish" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover coherent-trumpetfish`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted: 
 
 ```plain
 $ multipass list
@@ -204,7 +204,7 @@ primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
 ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 ```
 
-You've seen a few ways to create, customise, and delete an instance. Now put those instances to work!
+You've now seen a few ways to create, customise, and delete an instance. It is time to put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
 
@@ -226,7 +226,7 @@ Open a browser and type in the IP address of your instance into the address bar.
 
 Just like that, you've got a web server running in a Multipass instance!
 
-You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (For instance, a different computer), you need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
@@ -255,15 +255,15 @@ Copy the IP address starting with "10" and paste it into your browser, then add 
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-linux-5.png) 
 
-From there, select a local docker environment.
+From there, select **a local Docker environment**.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-linux-6.png) 
 
-Inside the newly selected local docker environment, navigate to the table of content, click on "app templates", and select NGINX.
+Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-linux-7.png) 
 
-From the Portainer dashboard, you can see the ports available on nginx. You can navigate to the IP address of your instance, followed by the port number to see that you indeed have nginx running in a docker container inside Multipass.
+From the Portainer dashboard, you can see the ports available on nginx. To verify that you have nginx running in a Docker container inside Multipass, open a web browser and paste the IP address of your instance followed by one of the port numbers.
 
 ![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-linux-8.png) 
 

--- a/multipass/Windows.md
+++ b/multipass/Windows.md
@@ -18,7 +18,7 @@ This tutorial will teach you how to create, customise and manage instances using
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOS, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-install-multipass). 
+Multipass is available for Linux, macOS and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-install-multipass). 
 
 This tutorial gives instructions for using Multipass on Windows.
 
@@ -276,7 +276,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options, and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options and more.
 
 Let us know what you’re able to get done with Multipass!
 

--- a/multipass/Windows.md
+++ b/multipass/Windows.md
@@ -18,7 +18,7 @@ This tutorial will teach you how to create, customise and manage instances using
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
+Multipass is available for Linux, macOS, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-install-multipass). 
 
 This tutorial gives instructions for using Multipass on Windows.
 
@@ -40,7 +40,7 @@ After launching the application, you should see the Multipass tray icon in the l
 
 **![|429x221](https://assets.ubuntu.com/v1/8c28e82a-mp-windows-2.png)**
 
-Click on the **Multipass icon**, then select **Open Shell**. 
+Click on the Multipass icon and select **Open Shell**. 
 
 **![|423x241](https://assets.ubuntu.com/v1/33a6bf4d-mp-windows-3.png)**
 
@@ -78,7 +78,7 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let’s test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Try out a few linux commands to see what you’re working with.
+Let’s test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Try out a few Linux commands to see what you’re working with.
 
 ```plain
 ubuntu@primary:~$ free
@@ -110,7 +110,7 @@ In Multipass, an instance with the name "primary" is privileged. That is, it ser
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all images you can currently launch through Multipass.
 
 ```plain
 C:\WINDOWS\system32> multipass find
@@ -174,7 +174,7 @@ You can now launch the type of instance you need by running this command:
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`.
 
 ```plain
 C:\WINDOWS\system32> multipass info ltsInstance                             
@@ -233,7 +233,7 @@ Open a browser and type in the IP address of your instance into the address bar.
 
 Just like that, you've got a web server running in a Multipass instance!
 
-You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. However, if you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
@@ -262,11 +262,11 @@ Copy the IP address starting with "10" and paste it into your browser, then add 
 
 ![|720x601](https://assets.ubuntu.com/v1/75a164a1-mp-windows-14.png)
 
-From there, select **a local Docker environment**
+From there, select **Local** to manage a local Docker environment.
 
 ![|720x460](https://assets.ubuntu.com/v1/ee3ff308-mp-windows-15.png)
 
-Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
+Inside the newly selected local Docker environment, locate the sidebar menu on the page and click on **app templates**, then select **NGINX**.
 
 ![](https://assets.ubuntu.com/v1/86be3eae-mp-windows-16.png)
 
@@ -276,7 +276,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you’re able to get done with Multipass!
 

--- a/multipass/Windows.md
+++ b/multipass/Windows.md
@@ -1,6 +1,6 @@
 nhart | 2023-12-04 11:27:40 UTC | #1
 
-Multipass is a flexible, powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. Used to a fuller extent, Multipass is a local mini-cloud on your laptop, allowing the testing and development of multi-instance or container-based cloud applications.
+Multipass is a flexible and powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. When used maximally, Multipass is a local mini-cloud on your laptop, ensuring that you can test and develop multi-instance or container-based cloud applications.
 
 This tutorial will teach you how to create, customise and manage instances using Multipass. You will also learn how to apply Multipass in two common use cases.
 
@@ -18,8 +18,9 @@ This tutorial will teach you how to create, customise and manage instances using
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, or Windows. To install it on your OS of choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). This tutorial gives instructions for using Multipass on Windows.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
 
+This tutorial gives instructions for using Multipass on Windows.
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
 
@@ -31,19 +32,21 @@ The primary instance is a Multipass virtual machine that is configured to be use
 The primary instance automatically mounts the $HOME directory (files in this directory are shared between the host and the instance), and it comes with Multipass’s default specs: 1GB of RAM, 5GB of disk, and 1 CPU.
 -->
 
-From the application launcher, let’s start Multipass. Press the Windows key and type Multipass, then launch the application from there.
+Start Multipass from the application launcher. Press the Windows key and type "Multipass", then launch the application.
 
 **![|720x625](https://assets.ubuntu.com/v1/50b86111-mp-windows-1.png)**
 
-Once we’ve launched the application, we should see the Multipass tray icon in the lower right section of the screen (you may need to click on the small arrow located there):
+After launching the application, you should see the Multipass tray icon in the lower right section of the screen (you may need to click on the small arrow located there).
 
 **![|429x221](https://assets.ubuntu.com/v1/8c28e82a-mp-windows-2.png)**
 
-Let's click on the icon, then on “Open Shell”. 
+Click on the **Multipass icon**, then select **Open Shell**. 
 
 **![|423x241](https://assets.ubuntu.com/v1/33a6bf4d-mp-windows-3.png)**
 
-Clicking this button does many things in the background: it creates a new virtual machine (instance), named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU; installs the most recent Ubuntu LTS release on that instance; mounts our $HOME directory in the instance; and opens a shell to the instance, announced by the command prompt `ubuntu@primary`. You can see elements of this in the printout below.
+Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named "primary", with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your `$HOME` directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+
+You can see elements of this in the printout below:
 
 ```plain
 Launched: primary                                                               
@@ -75,7 +78,7 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let’s test it out! As we just learned, the previous step automatically mounted our $HOME directory in the instance. Let’s try out a few linux commands to see what we’re working with:
+Let’s test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Try out a few linux commands to see what you’re working with.
 
 ```plain
 ubuntu@primary:~$ free
@@ -95,19 +98,19 @@ tmpfs                92580       4      92576   1% /run/user/1000
 
 Congratulations, you've got your first instance! 
 
-This instance is great for when we just need a quick Ubuntu VM, but let’s say we want a more customised instance. Multipass has us covered there too!
+This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance, how can you do that? Multipass has you covered there too.
 
 [details = "Optional Exercises"]
 Exercise 1: 
-When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+When you select Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name "primary" is privileged. That is, it serves as the default argument of `multipass shell` among other capabilities. In different terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help us get started creating customised instances. Let’s open a terminal and run the command `multipass find`. This shows us a list of all of the images we can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 C:\WINDOWS\system32> multipass find
@@ -137,16 +140,16 @@ jellyfin                                      latest           Jellyfin is a Fre
 minikube                                      latest           minikube is local Kubernetes
 ```
 
-Let’s launch an instance running Ubuntu 22.10 (“Kinetic Kudu”) by typing the command `multipass launch kinetic`
+Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the `multipass launch kinetic` command.
 
-Now we have an instance running which has been named randomly by Multipass, in my case it is called decorous-skate.
+Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "decorous-skate".
 
 ```plain
 C:\WINDOWS\system32> multipass launch kinetic
 Launched: decorous-skate
 ```
 
-We can check some basic info about our new instance by running the following:
+You can check some basic info about your new instance by running the following command:
 
 `multipass exec decorous-skate -- lsb_release -a`
 
@@ -161,17 +164,17 @@ Release:		22.10
 Codename:		kinetic
 ```
 
-Perhaps after using this instance for a while, we decide what we really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. We can delete the instance by running
+Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "decorous-skate" instance by running the following command:
 
 `multipass delete decorous-skate`
 
-Let’s now launch the type of instance we’re looking for by running this:
+You can now launch the type of instance you need by running this command:
 
 `multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-Now let’s confirm this new instance has the specs we’re looking for by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
 
 ```plain
 C:\WINDOWS\system32> multipass info ltsInstance                             
@@ -187,7 +190,7 @@ Memory usage:   170.4MiB out of 1.9GiB
 Mounts:         --
 ```
 
-We’ve created and deleted quite a few instances now. Let’s run Multipass list to see what instances we currently have.
+You've created and deleted quite a few instances. It is time to run `multipass list` to see the instances you currently have.
 
 ```plain
 C:\WINDOWS\system32> multipass list                                         
@@ -197,7 +200,7 @@ decorous-skate          Deleted           --               Not Available
 ltsInstance             Running           172.22.115.152   Ubuntu 22.04 LTS
 ```
 
-We have two instances currently running, the primary instance and our LTS machine with customised specs. Our decorous-skate instance is still listed, but its state is “Deleted”. We can recover this instance by running `multipass recover decorous-skate `, but for right now let’s delete the instance permanently by running `multipass purge`. Running `multipass list` again confirms the instance is now permanently deleted: 
+The result shows that you have two instances running, the "primary" instance and the LTS machine with customised specs. The "decorous-skate" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover decorous-skate`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted. 
 
 ```plain
 C:\WINDOWS\system32> multipass list
@@ -206,15 +209,17 @@ primary                 Running           10.110.66.242    Ubuntu 22.04 LTS
 ltsInstance             Running           172.22.115.152   Ubuntu 22.04 LTS
 ```
 
-We’ve now seen a few ways to create, customise, and delete an instance. Now let’s put those instances to work!
+You've now seen a few ways to create, customise, and delete an instance. It is time to put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
 
+One way to put a Multipass instance to use is by running a local or web server in it.
+
 <a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
 
-Let’s go back to that customised LTS instance we created. Take note of its IP address revealed by `multipass list` in the previous step, then run `multipass shell ltsInstance` to open a shell in the instance.
+Return to your customised LTS instance. Take note of its IP address, which was revealed when you ran `multipass list`. Then run `multipass shell ltsInstance` to open a shell in the instance.
 
-From the shell, we can now run:
+From the shell, you can run:
 
 ```
 sudo apt update
@@ -222,19 +227,19 @@ sudo apt update
 sudo apt install apache2
 ```
 
-Now, let’s open a browser and type in the IP address of the instance into the address bar. We should now see the default Apache homepage.
+Open a browser and type in the IP address of your instance into the address bar. You should now see the default Apache homepage.
 
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-windows-12.png)
 
-Just like that, we’ve got a web server running in a Multipass instance!
+Just like that, you've got a web server running in a Multipass instance!
 
-We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
-Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. The Docker Blueprint, for example, is a pre-configured Docker environment with a Portainer container already running. We can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`
+Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. For example, the Docker Blueprint is a pre-configured Docker environment with a Portainer container already running. You can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`.
 
-Once that’s finished, let’s run `multipass info docker-dev` to note down the IP of the new instance.
+Once that's done, run `multipass info docker-dev` to note down the IP of the new instance.
 
 ```plain
 C:\WINDOWS\system32> multipass launch docker --name docker-dev
@@ -253,25 +258,25 @@ Memory usage:   283.3MiB out of 3.8GiB
 Mounts:         --
 ```
 
-Let’s take the first IP address shown and paste it into our browser, then add a colon and the portainer default port, 9000, like this: 10.115.5.235:9000. This will take us to the Portainer login page, where we can set a username and password.
+Copy the IP address starting with "10" and paste it into your browser, then add a colon and the portainer default port, 9000. It should look like this: 10.115.5.235:9000. This will take you to the Portainer login page where you can set a username and password.
 
 ![|720x601](https://assets.ubuntu.com/v1/75a164a1-mp-windows-14.png)
 
-From there, let’s select a local docker environment.
+From there, select **a local Docker environment**
 
 ![|720x460](https://assets.ubuntu.com/v1/ee3ff308-mp-windows-15.png)
 
-From there, we can click into the newly created “local” docker endpoint, navigate to the app templates page, and select NGINX
+Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
 
 ![](https://assets.ubuntu.com/v1/86be3eae-mp-windows-16.png)
 
-From the Portainer dashboard, we can see the ports that nginx has available. We can navigate to the IP address of our instance followed by that port number to see that we indeed have nginx running in a docker container inside Multipass!
+From the Portainer dashboard, you can see the ports available on nginx. To verify that you have nginx running in a Docker container inside Multipass, open a new web page and paste the IP address of your instance followed by one of the port numbers.
 
 ![|720x465](https://assets.ubuntu.com/v1/f0b28200-mp-windows-17.png)
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You now have the skills you need to use Multipass proficiently. There’s more to learn about Multipass and its capabilities - check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and for help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you’re able to get done with Multipass!
 

--- a/multipass/macOS.md
+++ b/multipass/macOS.md
@@ -270,7 +270,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options, and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options and more.
 
 Let us know what you’re able to get done with Multipass!
 

--- a/multipass/macOS.md
+++ b/multipass/macOS.md
@@ -1,6 +1,6 @@
 nhart | 2023-08-23 15:59:54 UTC | #1
 
-Multipass is a flexible, powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. Used to a fuller extent, Multipass is a local mini-cloud on your laptop, allowing the testing and development of multi-instance or container-based cloud applications.
+Multipass is a flexible and powerful tool that can be used for many purposes. In its simplest form, it can be used to quickly create and destroy Ubuntu VMs (instances) on any host machine. When used maximally, Multipass is a local mini-cloud on your laptop, ensuring that you can test and develop multi-instance or container-based cloud applications.
 
 This tutorial will teach you how to create, customise and manage instances using Multipass. You will also learn how to apply Multipass in two common use cases.
 
@@ -18,8 +18,9 @@ This tutorial will teach you how to create, customise and manage instances using
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, or Windows. To install it on your OS of choice, please follow the instructions given [here](https://multipass.run/docs/how-to-guides). This tutorial gives instructions for using Multipass on macOS.
+Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
 
+This tutorial gives instructions for using Multipass on macOS.
 
 <a href="#heading--create-and-use-a-basic-instance"><h2 id="heading--create-and-use-a-basic-instance">Create and use a basic instance</h2></a>
 
@@ -31,19 +32,21 @@ The primary instance is a Multipass virtual machine that is configured to be use
 The primary instance automatically mounts the $HOME directory (files in this directory are shared between the host and the instance), and it comes with Multipass’s default specs: 1GB of RAM, 5GB of disk, and 1 CPU.
 -->
 
-From the application launcher, let's start Multipass. In macOS, open the application launcher, type Multipass, and launch the application.
+Start Multipass from the application launcher. In macOS, open the application launcher, type "Multipass", and launch the application.
 
 **![|720x451](https://assets.ubuntu.com/v1/a4ff7fad-mp-macos-1.png)**
 
-Once we’ve launched the application, we should see the Multipass tray icon in the upper right section of the screen:
+After launching the application, you should see the Multipass tray icon in the upper right section of the screen
 
 **![|684x48](https://assets.ubuntu.com/v1/42bb4ccb-mp-macos-2.png)**
 
-Let's click on the icon, then on “Open Shell”. 
+Click on the **Multipass icon**, then select **Open Shell**. 
 
 **![|304x352](https://assets.ubuntu.com/v1/eb92083a-mp-macos-3.png)**
 
-Clicking this button does many things in the background: it creates a new virtual machine (instance), named `primary`, with 1GB of RAM, 5GB of disk, and 1 CPU; installs the most recent Ubuntu LTS release on that instance; mounts our $HOME directory in the instance; and opens a shell to the instance, announced by the command prompt `ubuntu@primary`. You can see elements of this in the printout below.
+Clicking this button does many things in the background. First, it creates a new virtual machine (instance) named "primary", with 1GB of RAM, 5GB of disk, and 1 CPU. Second, it installs the most recent Ubuntu LTS release on that instance. Third, it mounts your `$HOME` directory in the instance. Last, it opens a shell to the instance, announced by the command prompt `ubuntu@primary`. 
+
+You can see elements of this in the printout below:
 
 ```plain
 Launched: primary                                                               
@@ -71,11 +74,11 @@ To check for new updates run: sudo apt update
 ubuntu@primary:~$
 ```
 
-Let's test it out! As we just learned, the previous step automatically mounted our $HOME directory in the instance. Let's use this to share data with our instance. More concretely, let’s create a new folder in our $HOME directory called Multipass_Files:
+Let’s test it out. As you've just learnt, the previous step automatically mounted your `$HOME` directory in the instance. Use this to share data with your instance. More concretely, create a new folder called `Multipass_Files` in your `$HOME` directory.
 
 **![|720x329](https://assets.ubuntu.com/v1/5867fb49-mp-macos-4.png)**
 
-As you can see, I've added a readme file in this shared folder. Let's check for the folder and read the file from our new instance:
+As you can see, a readme file has been added in this shared folder. Check for the folder and read the file from your new instance:
 
 ```plain
 ubuntu@primary:~$ cd ./Home/Multipass_Files/
@@ -89,19 +92,19 @@ ubuntu@primary:~/Home/Multipass_Files$
 
 Congratulations, you've got your first instance! 
 
-This instance is great for when we just need a quick Ubuntu VM, but let’s say we want a more customised instance. Multipass has us covered there too!
+This instance is great for when you just need a quick Ubuntu VM, but let's say you want a more customised instance, how can you do that? Multipass has you covered there too.
 
 [details = "Optional Exercises"]
 Exercise 1: 
-When you clicked on Open Shell just now, what happened in the background was the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
+When you select Open Shell, what happens in the background is the equivalent of the CLI commands `multipass launch –name primary`  followed by  `multipass shell`. Open a terminal and try `multipass shell` (if you didn't follow the steps above, you will have to run the `launch` command first).
 
 Exercise 2: 
-In Multipass, an instance with the name `primary` is privileged. For example, it is the default argument of multipass shell. In two terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
+In Multipass, an instance with the name "primary" is privileged. That is, it serves as the default argument of `multipass shell` among other capabilities. In different terminal instances, check `multipass shell primary` and `multipass shell`. Both commands should give the same result.
 [/details]
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help us get started creating customised instances. Let’s open a terminal and run the command `multipass find`. This shows us a list of all of the images we can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
 
 ```plain
 $ multipass find
@@ -131,16 +134,16 @@ jellyfin                                      latest           Jellyfin is a Fre
 minikube                                      latest           minikube is local Kubernetes
 ```
 
-Let’s launch an instance running Ubuntu 22.10 (“Kinetic Kudu”) by typing the command `multipass launch kinetic`
+Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the `multipass launch kinetic` command.
 
-Now we have an instance running which has been named randomly by Multipass, in my case it is called breezy-liger.
+Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "breezy-liger".
 
 ```plain
 $ multipass launch kinetic
 Launched: breezy-liger
 ```
 
-We can check some basic info about our new instance by running the following:
+You can check some basic info about your new instance by running the following command:
 
 `multipass exec breezy-liger -- lsb_release -a`
 
@@ -155,17 +158,17 @@ Release:		22.10
 Codename:		kinetic
 ```
 
-Perhaps after using this instance for a while, we decide what we really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. We can delete the breezy-liger instance by running
+Perhaps after using this instance for a while, you decide that what you really need is the latest LTS version of Ubuntu, with a more informative name and a little more memory and disk. You can delete the "breezy-liger" instance by running the following command:
 
 `multipass delete breezy-liger`
 
-Let’s now launch the type of instance we’re looking for by running this:
+You can now launch the type of instance you need by running this command:
 
 `multipass launch lts --name ltsInstance --memory 2G --disk 10G --cpus 2`
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-Now let’s confirm this new instance has the specs we’re looking for by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
 
 ```plain
 $ multipass info ltsInstance                             
@@ -181,7 +184,7 @@ Memory usage:   155.5MiB out of 1.9GiB
 Mounts:         --
 ```
 
-We’ve created and deleted quite a few instances now. Let’s run Multipass list to see what instances we currently have.
+You've created and deleted quite a few instances. It is time to run `multipass list` to see the instances you currently have.
 
 ```plain
 $ multipass list                                         
@@ -191,7 +194,7 @@ breezy-liger            Deleted           --               Not Available
 ltsInstance             Running           192.168.64.3     Ubuntu 22.04 LTS
 ```
 
-We have two instances currently running, the primary instance and our LTS machine with customised specs. Our breezy-liger instance is still listed, but its state is “Deleted”. We can recover this instance by running `multipass recover breezy-liger `, but for right now let’s delete the instance permanently by running `multipass purge`. Running `multipass list` again confirms the instance is now permanently deleted: 
+The result shows that you have two instances running, the "primary" instance and the LTS machine with customised specs. The "breezy-liger" instance is still listed, but its state is "Deleted". You can recover this instance by running `multipass recover breezy-liger`. But for now, delete the instance permanently by running `multipass purge`. Then run `multipass list` again to confirm that the instance has been permanently deleted. 
 
 ```plain
 $ multipass list                                         
@@ -200,15 +203,17 @@ primary                 Running           192.168.64.5     Ubuntu 22.04 LTS
 ltsInstance             Running           192.168.64.3     Ubuntu 22.04 LTS
 ```
 
-We’ve now seen a few ways to create, customise, and delete an instance. Now let’s put those instances to work!
+You've now seen a few ways to create, customise, and delete an instance. It is time to put those instances to work!
 
 <a href="#heading--put-your-instances-to-use"><h2 id="heading--put-your-instances-to-use">Put your instances to use</h2></a>
 
+One way to put a Multipass instance to use is by running a local or web server in it.
+
 <a href="#heading--run-a-simple-web-server"><h3 id="heading--run-a-simple-web-server">Run a simple web server</h3></a>
 
-Let’s go back to that customised LTS instance we created. Take note of its IP address revealed by `multipass list` in the previous step, then run `multipass shell ltsInstance` to open a shell in the instance.
+Return to your customised LTS instance. Take note of its IP address, which was revealed when you ran `multipass list`. Then run `multipass shell ltsInstance` to open a shell in the instance.
 
-From the shell, we can now run:
+From the shell, you can run:
 
 ```
 sudo apt update
@@ -216,19 +221,19 @@ sudo apt update
 sudo apt install apache2
 ```
 
-Now, let’s open a browser and type in the IP address of the instance into the address bar. We should now see the default Apache homepage.
+Open a browser and type in the IP address of your instance into the address bar. You should now see the default Apache homepage.
 
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-macos-5.png)
 
-Just like that, we’ve got a web server running in a Multipass instance!
+Just like that, you've got a web server running in a Multipass instance!
 
-We can use this web server locally for any kind of local development or testing we like. If however, we want to access this web server from the internet (e.g. from a different computer), we need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
-Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. The Docker Blueprint, for example, is a pre-configured Docker environment with a Portainer container already running. We can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`
+Some environments require a lot of configuration and setup. Multipass Blueprints are instances with a deep level of customization. For example, the Docker Blueprint is a pre-configured Docker environment with a Portainer container already running. You can launch an instance using the Docker Blueprint by running `multipass launch docker --name docker-dev`.
 
-Once that’s finished, let’s run `multipass info docker-dev` to note down the IP of the new instance.
+Once that's done, run `multipass info docker-dev` to note down the IP of the new instance.
 
 ```plain
 $ multipass launch docker --name docker-dev
@@ -247,25 +252,25 @@ Memory usage:   236.4MiB out of 3.8GiB
 Mounts:         --
 ```
 
-Let’s take the first IP address shown and paste it into our browser, then add a colon and the portainer default port, 9000, like this: 10.115.5.235:9000. This will take us to the Portainer login page, where we can set a username and password.
+Copy the IP address starting with "10" and paste it into your browser, then add a colon and the portainer default port, 9000. It should look like this: 10.115.5.235:9000. This will take you to the Portainer login page where you can set a username and password.
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-macos-6.png)
 
-From there, let’s select a local docker environment.
+From there, select **a local Docker environment**.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-macos-7.png)
 
-From there, we can click into the newly created “local” docker endpoint, navigate to the app templates page, and select NGINX
+Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-macos-8.png)
 
-From the Portainer dashboard, we can see the ports that nginx has available. We can navigate to the IP address of our instance followed by that port number to see that we indeed have nginx running in a docker container inside Multipass!
+From the Portainer dashboard, you can see the ports available on nginx. To verify that you have nginx running in a Docker container inside Multipass, open a new web page and paste the IP address of your instance followed by one of the port numbers.
 
 ![|720x465](https://assets.ubuntu.com/v1/25585a03-mp-macos-9.png)
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You now have the skills you need to use Multipass proficiently. There’s more to learn about Multipass and its capabilities - check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and for help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you’re able to get done with Multipass!
 

--- a/multipass/macOS.md
+++ b/multipass/macOS.md
@@ -18,7 +18,7 @@ This tutorial will teach you how to create, customise and manage instances using
 
 <a href="#heading--install-multipass"><h2 id="heading--install-multipass">Install Multipass</h3></a>
 
-Multipass is available for Linux, macOs, and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-guides). 
+Multipass is available for Linux, macOS and Windows. To install it on the OS of your choice, please follow the instructions given in this [how-to-guides](https://multipass.run/docs/how-to-install-multipass). 
 
 This tutorial gives instructions for using Multipass on macOS.
 
@@ -36,11 +36,11 @@ Start Multipass from the application launcher. In macOS, open the application la
 
 **![|720x451](https://assets.ubuntu.com/v1/a4ff7fad-mp-macos-1.png)**
 
-After launching the application, you should see the Multipass tray icon in the upper right section of the screen
+After launching the application, you should see the Multipass tray icon in the upper right section of the screen.
 
 **![|684x48](https://assets.ubuntu.com/v1/42bb4ccb-mp-macos-2.png)**
 
-Click on the **Multipass icon**, then select **Open Shell**. 
+Click on the Multipass icon and select **Open Shell**. 
 
 **![|304x352](https://assets.ubuntu.com/v1/eb92083a-mp-macos-3.png)**
 
@@ -78,7 +78,7 @@ Let’s test it out. As you've just learnt, the previous step automatically moun
 
 **![|720x329](https://assets.ubuntu.com/v1/5867fb49-mp-macos-4.png)**
 
-As you can see, a readme file has been added in this shared folder. Check for the folder and read the file from your new instance:
+As you can see, a `README.md` file has been added to the shared folder. Check for the folder and read the file from your new instance:
 
 ```plain
 ubuntu@primary:~$ cd ./Home/Multipass_Files/
@@ -104,7 +104,7 @@ In Multipass, an instance with the name "primary" is privileged. That is, it ser
 
 <a href="#heading--create-a-customised-instance"><h2 id="heading--create-a-customised-instance">Create a customised instance</h3></a>
 
-Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all of the images you can launch through Multipass currently.
+Multipass has a great feature to help you get started with creating customised instances. Open a terminal and run the `multipass find` command. The result shows a list of all images you can currently launch through Multipass.
 
 ```plain
 $ multipass find
@@ -168,7 +168,7 @@ You can now launch the type of instance you need by running this command:
 
 <a href="#heading--manage-instances"><h2 id="heading--manage-instances">Manage instances</h3></a>
 
-You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`
+You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`.
 
 ```plain
 $ multipass info ltsInstance                             
@@ -227,7 +227,7 @@ Open a browser and type in the IP address of your instance into the address bar.
 
 Just like that, you've got a web server running in a Multipass instance!
 
-You can use this web server locally for any kind of local development or testing. If however, you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
+You can use this web server locally for any kind of local development or testing. However, if you want to access this web server from the internet (for instance, a different computer), you need an instance that is exposed to the external network.
 
 <a href="#heading--launch-from-a-blueprint-to-run-docker-containers"><h3 id="heading--launch-from-a-blueprint-to-run-docker-containers">Launch from a Blueprint to run Docker containers</h3></a>
 
@@ -256,11 +256,11 @@ Copy the IP address starting with "10" and paste it into your browser, then add 
 
 ![|720x543](https://assets.ubuntu.com/v1/75a164a1-mp-macos-6.png)
 
-From there, select **a local Docker environment**.
+From there, select **Local** to manage a local Docker environment.
 
 ![|720x601](https://assets.ubuntu.com/v1/ee3ff308-mp-macos-7.png)
 
-Inside the newly selected local Docker environment, navigate to the **table of contents**, click on **app templates**, and select **NGINX**.
+Inside the newly selected local Docker environment, locate the sidebar menu on the page and click on **app templates**, then select **NGINX**.
 
 ![|720x460](https://assets.ubuntu.com/v1/86be3eae-mp-macos-8.png)
 
@@ -270,7 +270,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 <a href="#heading--next-steps"><h2 id="heading--next-steps">Next steps</h2></a>
 
-Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference page](https://multipass.run/docs/reference) contains definitions of key concepts, a complete CLI command reference, settings options, and more.
+Congratulations! You can now use Multipass proficiently. There's more to learn about Multipass and its capabilities. Check out our [how-to guides](https://multipass.run/docs/how-to-guides) for ideas and help with your project. Our [reference pages](https://multipass.run/docs/reference) contain definitions of key concepts, a complete CLI command reference, settings options, and more.
 
 Let us know what you’re able to get done with Multipass!
 


### PR DESCRIPTION
Did things like (https://github.com/canonical/open-documentation-academy/issues/55 ): made sentences more concise, aligned writing with canonical documentation guideline by ensuring that words and phrases that should be avoided are avoided - pronouns are used right and consistently - and words are British instead of American, corrected grammatical errrors by using words (like the word , spotting when it is used as an adverb and when it is not) and punctuations properly, and re-wrote confusing sentences.

Will work on Windows and macOS. Wanted to push this and get response on whether it is being done right