### PR TITLE
Snapcraft: fix for merged PR #109 (issue #3)

### DIFF
--- a/snapcraft/how-to/qt-applications/github/scripts/set-cursor-variables
+++ b/snapcraft/how-to/qt-applications/github/scripts/set-cursor-variables
@@ -24,7 +24,7 @@ if [[ -z "$DISABLE_WAYLAND" && ( -e "$XDG_RUNTIME_DIR/../$WAYLAND_DISPLAY" || -e
     export XCURSOR_THEME="$(busctl call --user $DBUS_SERVICE $DBUS_OBJECT $DBUS_INTERFACE ReadOne ss $DBUS_TARGET cursor-theme | cut -d \" -f2)"
   fi
   if [ ! -v XCURSOR_SIZE ]; then
-    export XCURSOR_SIZE="$(busctl call --user $DBUS_SERVICE $DBUS_OBJECT $DBUS_INTERFACE ReadOne ss $DBUS_TARGET cursor-size | cut -d' ' -f4)"
+    export XCURSOR_SIZE="$(busctl call --user $DBUS_SERVICE $DBUS_OBJECT $DBUS_INTERFACE ReadOne ss $DBUS_TARGET cursor-size | cut -d' ' -f3)"
   fi
 fi
 


### PR DESCRIPTION
This is a really small fix for the `set-cursor-variables` script relied on by the `kcalc-example` snap included in PR #109 (see also issue #3).

The script originally relied on the `Read` method provided by `org.freedesktop.portal.Settings`. I changed it to use the `ReadOne` method after learning that `Read` had been deprecated, but hadn't taken into account that the output of `ReadOne` differs slightly from `Read`, meaning that the script didn't set the cursor size as expected.