### PR TITLE
Snapcraft: updates to documentation for the dump plugin (issue #96)

### DIFF
--- a/snapcraft/reference/dump-plugin.md
+++ b/snapcraft/reference/dump-plugin.md
@@ -1,30 +1,41 @@
-This plugin dumps the content from a specified source. 
+The `dump` plugin copies the contents of a *source* into the root directory of the snap, without running any language-specific packaging logic. It provides an easy way to add pre-built binaries, scripts and other assets to a snap.
 
-You can specify various details about such a source using [source keywords](/t/snapcraft-parts-metadata/8336#heading--source), such as `source` and `source-type`.
+The *source* is defined using the [common keywords for sources](/t/snapcraft-parts-metadata/8336#heading--source).
 
-This plugin uses also [common plugin keywords](/t/snapcraft-plugins/8336). 
-Such keywords can, for example, be useful when the dumped content needs to be mangled or organised in some way. Using keywords such as `filesets`, `stage`, `snap` and `organize` can be useful in such cases.
-
-For example:
+The following example shows how the `dump` plugin can be used with a remote compressed tarball:
 
 ```yaml
 parts:
-  my-part:
-    source: local-source/
+  my-remote-part:
     plugin: dump
-    organize:
-      '*.png' : images/
-      launch.wrapper: usr/bin/launcher
-    prime:
-      - -README*
-  remote-part:
-    plugin: dump
-    source: https://remote-resource.org/cool-package.deb
-    source-type: deb
+    source: https://www.example.com/builds/latest-build.tar.gz
 ```
 
-See [source keywords](/t/snapcraft-parts-metadata/8336#heading--source) and [common plugin keywords](/t/snapcraft-plugins/4284) for more information.
+The behaviour of the `dump` plugin can be modified using optional [common plugin keywords](/t/snapcraft-parts-metadata/8336). For example:
+* the `organize` keyword can be used to move and rename files and directories contained in the source;
+* the `stage` and `prime` keywords can be used to specify which certain files and directories should (and should not) be copied into the snap; and
+* the `override-build`, `override-stage` and `override-prime` keywords provide a way of running [custom shell scripts](/t/overrides/4892) during the build process
 
-For more examples, click here to find [GitHub](https://github.com/search?o=desc&q=path%3Asnapcraft.yaml+%22plugin%3A+dump%22+&s=indexed&type=Code&utf8=%E2%9C%93) projects already using this plugin.
+These keywords are particularly useful when building a snap from multiple component parts, where the main application expects to find supporting binaries, libraries and assets (such as themes or plugins) in specific locations. They are also useful when the source contains components for multiple [architectures](/t/architectures/4972), where it is only necessary to copy files for one architecture into the snap.
+
+Note that the `organize` keyword is processed *before* `stage` and `prime`. This means that any `stage` and `prime` entries should refer to the files as renamed and/or moved, and not to the original names and locations.
+
+The following example is based on a source tarball that contains directories named `binaries`, `docs` and `etc`, as well as files named `COPYRIGHT` and `README`. The `organize` keyword moves the `binaries` directory and `COPYRIGHT` file to `usr/bin` and `usr/share/doc/my-app/COPYRIGHT` respectively. The `stage` keyword copies everything other  than the `docs` directory and `README` file into the snap.
+
+```yaml
+parts:
+  my-app-part:
+    plugin: dump
+    source: https://www.example.com/builds/latest-build.tar.gz
+    organize:
+      binaries: usr/bin
+      COPYRIGHT: usr/share/doc/my-app/COPYRIGHT
+    stage:
+      - -README
+      - -docs
+```
+
+For more examples, see [Pre-built apps](/t/pre-built-apps/6739) or [search for GitHub projects](https://github.com/search?o=desc&q=path%3Asnapcraft.yaml+%22plugin%3A+dump%22+&s=indexed&type=Code&utf8=%E2%9C%93) already using this plugin.
 
 > ⓘ  This is a *snapcraft* plugin. See [Snapcraft plugins](/t/snapcraft-plugins/4284) and [Supported plugins](/t/supported-plugins/8080) for further details on how plugins are used.
+> 

--- a/snapcraft/reference/dump-plugin.md
+++ b/snapcraft/reference/dump-plugin.md
@@ -1,0 +1,30 @@
+This plugin dumps the content from a specified source. 
+
+You can specify various details about such a source using [source keywords](/t/snapcraft-parts-metadata/8336#heading--source), such as `source` and `source-type`.
+
+This plugin uses also [common plugin keywords](/t/snapcraft-plugins/8336). 
+Such keywords can, for example, be useful when the dumped content needs to be mangled or organised in some way. Using keywords such as `filesets`, `stage`, `snap` and `organize` can be useful in such cases.
+
+For example:
+
+```yaml
+parts:
+  my-part:
+    source: local-source/
+    plugin: dump
+    organize:
+      '*.png' : images/
+      launch.wrapper: usr/bin/launcher
+    prime:
+      - -README*
+  remote-part:
+    plugin: dump
+    source: https://remote-resource.org/cool-package.deb
+    source-type: deb
+```
+
+See [source keywords](/t/snapcraft-parts-metadata/8336#heading--source) and [common plugin keywords](/t/snapcraft-plugins/4284) for more information.
+
+For more examples, click here to find [GitHub](https://github.com/search?o=desc&q=path%3Asnapcraft.yaml+%22plugin%3A+dump%22+&s=indexed&type=Code&utf8=%E2%9C%93) projects already using this plugin.
+
+> ⓘ  This is a *snapcraft* plugin. See [Snapcraft plugins](/t/snapcraft-plugins/4284) and [Supported plugins](/t/supported-plugins/8080) for further details on how plugins are used.


### PR DESCRIPTION
This pull request relates to issue #96.

The main aim of the amended documentation is to provide additional detail on how developers can customise the behaviour of the `dump` plugin using plugin keywords such as `organize`, `stage` and `prime`.

I tweaked the example to be *slightly* less arbitrary, reduced it to just one part, and split it into two versions (the first shows the simplest use of the `dump` plugin, whilst the other introduces `organize` and `stage`).

I wasn't sure how much we needed to discuss "the choices that go into creating a specific layout" - to this end I simply gave a couple of examples. To be honest, I'm not particularly happy about that paragraph, and wouldn't mind if it were removed.

I also took the opportunity to tweak some of the remaining language, e.g. so that the introductory section aligns a little bit more with some of the other plugin guides.

I *think* that I have sufficient trust on the Snapcraft discourse to update the documentation once it's ready.