### PR TITLE
docs: improve reference page on Ubuntu distributions

### DIFF
--- a/wsl/reference/distributions.md
+++ b/wsl/reference/distributions.md
@@ -34,5 +34,5 @@ These naming conventions are summarised in the table below:
 
 :::{note}
 The kernel used in WSL environments is maintained by Microsoft.
-Bug reports and support requests for the WSL kernel should be direct to the official repository for the WSL kernel.
+Bug reports and support requests for the WSL kernel should be directed to the [official repository for the WSL kernel](https://github.com/microsoft/WSL2-Linux-Kernel).
 :::

--- a/wsl/reference/distributions.md
+++ b/wsl/reference/distributions.md
@@ -1,26 +1,38 @@
 # Distributions
 
-Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. However, we develop several flavours for the Ubuntu distro and one or more of these flavours may fit your needs better.
+Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. Several releases of the Ubuntu distro are available for WSL.
 
-Each of these flavours corresponds to a different application on the Microsoft Store, and once installed, they'll create different flavors in your WSL. 
 
-## Ubuntu Variants
-These are the variants of the default Ubuntu flavor we develop and maintain:
+Each release of Ubuntu for WSL is available as an application from the Microsoft Store. Once a release is [installed](https://documentation.ubuntu.com/wsl/en/latest/howto/install-ubuntu-wsl2/#method-1-microsoft-store-application), it will be available to use in your WSL environment. 
 
-- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS release of Ubuntu. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available.
-- Numbered releases, for example [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) refer to specific Long Term Stability (LTS) releases that are supported for five years. For more information on releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases).
-- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu previewing new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
+## Releases of Ubuntu on WSL
+These are the releases of Ubuntu that we support and that are available on the Microsoft Store:
+
+- [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS (Long Term Support) release of Ubuntu. When new LTS versions are released, this release of Ubuntu can be upgraded once the first point release is available.
+- Numbered releases, for example [Ubuntu 22.04 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US), refer to specific Long Term Stability (LTS) releases that receive standard support for five years. For more information on LTS releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases). Numbered releases of Ubuntu on WSL will not be upgraded unless configured to upgrade in `etc/update-manager/release-upgrades`.
+- [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu, which previews new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
+
+:::{note}
+Interim releases of Ubuntu are currently not supported on WSL.
+:::
 
 ## Naming
-The variants of the default Ubuntu flavor is available under different names depending the context you try to access it with. Here is a table matching them.
+Depending on context, releases of Ubuntu are referred to by different names: 
 
-1. App name is the name you'll see in the Microsoft Store and Winget.
-2. AppxPackage is the name you'll see in `Get-AppxPackage`.
-3. Distro name is the name you'll see when doing `wsl -l -v` or `wsl -l --online`.
-4. Executable is the program you need to run to start the distro.
+1. **App name** is the name of the application for a specific Ubuntu release that you will see in the Microsoft Store.  
+2. **AppxPackage** is the name that can be passed to `Get-AppxPackage -Name` in PowerShell to get information about an installed package. 
+3. **Distro name** is the name logged when you invoke `wsl -l -v` to list installed releases of Ubuntu.  
+4. **Executable** is the program you need to run to start the Ubuntu distro.
 
-| App name             | AppxPackage name                       | Variant      | Executable          |
+These naming conventions are summarised in the table below:
+
+| App name             | AppxPackage name                       | Distro name      | Executable          |
 | -------------------- | -------------------------------------- | ---------------- | ------------------- |
 | `Ubuntu`             | `CanonicalGroupLimited.Ubuntu`         | `Ubuntu`         | `ubuntu.exe`        |
 | `Ubuntu (Preview)`   | `CanonicalGroupLimited.UbuntuPreview`  | `Ubuntu-Preview` | `ubuntupreview.exe` |
 | `Ubuntu XX.YY.Z LTS` | `CanonicalGroupLimited.UbuntuXX.YYLTS` | `Ubuntu-XX.YY`   | `ubuntuXXYY.exe`    |
+
+:::{note}
+The kernel used in WSL environments is maintained by Microsoft.
+Bug reports and support requests for the WSL kernel should be direct to the official repository for the WSL kernel.
+:::

--- a/wsl/reference/distributions.md
+++ b/wsl/reference/distributions.md
@@ -4,6 +4,7 @@ Our flagship distribution (distro) is Ubuntu. It is the default option when you 
 
 Each of these flavours corresponds to a different application on the Microsoft Store, and once installed, they'll create different flavors in your WSL. 
 
+## Ubuntu Variants
 These are the variants of the default Ubuntu flavor we develop and maintain:
 
 - [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS release of Ubuntu. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available.

--- a/wsl/reference/distributions.md
+++ b/wsl/reference/distributions.md
@@ -1,23 +1,24 @@
 # Distributions
 
-Our flagship distribution is Ubuntu. This is the one that is installed by default when you install WSL for the first time. However, we develop several flavours. It may be the case that one or more of these flavours fits your needs better.
+Our flagship distribution (distro) is Ubuntu. It is the default option when you install WSL for the first time. However, we develop several flavours for the Ubuntu distro and one or more of these flavours may fit your needs better.
 
-Each of these flavours corresponds to a different application on the Microsoft Store, and once installed, they'll create different distros in your WSL. These are the applications we develop and maintain:
+Each of these flavours corresponds to a different application on the Microsoft Store, and once installed, they'll create different flavors in your WSL. 
+
+These are the variants of the default Ubuntu flavor we develop and maintain:
 
 - [Ubuntu](https://apps.microsoft.com/detail/9PDXGNCFSCZV?hl=en-us&gl=US) ships the latest stable LTS release of Ubuntu. When new LTS versions are released, Ubuntu can be upgraded once the first point release is available.
-- [Ubuntu 18.04.6 LTS](https://apps.microsoft.com/detail/9PNKSF5ZN4SW?hl=en-us&gl=US), [Ubuntu 20.04.6 LTS](https://apps.microsoft.com/detail/9MTTCL66CPXJ?hl=en-us&gl=US), and [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) are the LTS versions of Ubuntu and receive updates for five years. Upgrades to future LTS releases will not be proposed.
+- Numbered releases, for example [Ubuntu 22.04.3 LTS](https://apps.microsoft.com/detail/9PN20MSR04DW?hl=en-us&gl=US) refer to specific Long Term Stability (LTS) releases that are supported for five years. For more information on releases, support and timelines, visit the [Ubuntu releases page](https://wiki.ubuntu.com/Releases).
 - [Ubuntu (Preview)](https://apps.microsoft.com/detail/9P7BDVKVNXZ6?hl=en-us&gl=US) is a daily build of the latest development version of Ubuntu previewing new features as they are developed. It does not receive the same level of QA as stable releases and should not be used for production workloads.
 
 ## Naming
-
-Due to different limitations in different contexts, these applications will have different names in different contexts. Here is a table matching them.
+The variants of the default Ubuntu flavor is available under different names depending the context you try to access it with. Here is a table matching them.
 
 1. App name is the name you'll see in the Microsoft Store and Winget.
 2. AppxPackage is the name you'll see in `Get-AppxPackage`.
 3. Distro name is the name you'll see when doing `wsl -l -v` or `wsl -l --online`.
 4. Executable is the program you need to run to start the distro.
 
-| App name             | AppxPackage name                       | Distro name      | Executable          |
+| App name             | AppxPackage name                       | Variant      | Executable          |
 | -------------------- | -------------------------------------- | ---------------- | ------------------- |
 | `Ubuntu`             | `CanonicalGroupLimited.Ubuntu`         | `Ubuntu`         | `ubuntu.exe`        |
 | `Ubuntu (Preview)`   | `CanonicalGroupLimited.UbuntuPreview`  | `Ubuntu-Preview` | `ubuntupreview.exe` |


### PR DESCRIPTION
closes issue #157 
@edibotopic I was able to address the parts of the issue related to Technical debt, Confusing terminology, and Poor phrasing. Please review and let me know what you think. I need some clarification on the remaining 2 parts.
- Clarification on kernel support: For this part, you mentioned "a common source of confusion is that the Ubuntu WSL maintainers also maintain the WSL kernel." but the current reference doesn't suggest this in any way.
- Structure: For this part, you mentioned, "there is content above that which also refers to naming conventions." this is also not included in this reference page.
