### PR TITLE
Updated get_started.md to separate Windows-specific steps and install_git.md to fix typos.

### DIFF
--- a/getting-started/get_started.md
+++ b/getting-started/get_started.md
@@ -11,15 +11,21 @@ The GitHub documentation is rather good, if you get stuck or need any explanatio
 
 ## Getting your environment set up
 
-Where you start in this series will depend on whether you're using a Windows machine, or an Ubuntu one. If you're using Windows, start on Part 1. If you are running Ubuntu, or have a dual-boot system where one of your options is Ubuntu, feel free to skip Part 1 and go straight to Part 2. 
+If you're using a Windows machine, start by following these instructions:
 
-1. [Getting started using Windows](start_with_WSL.md)
-2. [Install and configure git](install_git.md)
-3. [Working with git on the command line](using_git.md)
+  * [Getting started using Windows](start_with_WSL.md).
 
-## Optional steps
+Continue as follows whether you are using Windows or Ubuntu.
 
-1. [Set up Sphinx](setup_sphinx.md)
-   This applies if you are working on a project that uses Sphinx to render the documentation.
-1. [Command line cheat sheet](CLI_basics.md)
-   This reference will help remind you of the basic commands needed to work with files on the command line.
+1. [Install and configure git](install_git.md)
+1. [Working with git on the command line](using_git.md)
+
+If you are working on a project that uses Sphinx to render the documentation, continue with:
+
+  * [Set up Sphinx](setup_sphinx.md)
+
+## Reference ##
+
+This reference will remind you of the basic commands needed to work with files on the command line.
+
+  * [Command line cheat sheet](CLI_basics.md)

--- a/getting-started/install_git.md
+++ b/getting-started/install_git.md
@@ -92,7 +92,7 @@ Now that we are inside the new folder, we need to find the "address" for the rep
 
 Now, we can click on the green button that says `< > Code`, click on the "Local" tab, and then on the HTTPS sub-tab. Copy the URL that's shown in the box below that. 
 
-![clone the repository](clone_repo.png)
+![clone the repository](images/clone_repo.png)
 
 We can then return to our terminal window and clone the repository - the command always looks something like this:
 
@@ -103,7 +103,7 @@ git clone <repository URL or SSH address>
 In this case, we want to use the HTTPS link, so run this command to clone the Open Documentation Academy repository:
 
 ```bash
-https://github.com/canonical/open-documentation-academy
+git clone https://github.com/canonical/open-documentation-academy.git
 ```
 
 This will download everything into a new folder *inside your `src` folder*, called "open-documentation-academy". This will be important later!


### PR DESCRIPTION
Updated get_started.md to separate Windows-specific steps 
Updated install_git.md to (i) point at images/clone_repo.png and (ii) provide the whole clone command, HTTP version, i.e. 

git clone https://github.com/canonical/open-documentation-academy.git
