### PR TITLE
Add MicroCeph to list of participating projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The first words of an issue's title will typically indicate the project it invol
 - [Landscape](https://ubuntu.com/landscape/docs): Ubuntu systems management, monitoring and administration platform
 - [Launchpad](https://documentation.ubuntu.com/launchpad/en/latest/): software development lifecycle and collaboration platform
 - [MAAS](https://maas.io/docs): bare metal cloud with on-demand servers
+- [MicroCeph](https://canonical-microceph.readthedocs-hosted.com/en/squid-stable/): the easiest way to get up and running with Ceph
 - [MicroStack](https://microstack.run/docs): our next generation enterprise cloud solution
 - [Multipass](https://discourse.ubuntu.com/t/multipass-documentation/8294): tool to generate cloud-style Ubuntu virtual machines
 - [Netplan](https://github.com/canonical/netplan): network configuration for various backends


### PR DESCRIPTION
Hiya,

We've just added [our first task](https://github.com/canonical/open-documentation-academy/issues/174) to the issues list, and are happy and proud to officially join the impressive list of participating projects.

Thank you!