### PR TITLE
docs: Fix web build after restructure

### DIFF
--- a/website/.custom_wordlist.txt
+++ b/website/.custom_wordlist.txt
@@ -1,4 +1,31 @@
 # Leave a blank line at the end of this file to support concatenation
+ADSys
+Anbox
+AsciiDoc
+backends
+bootable
+Ctrl
+docsacademy
+freesewing
+https
+IoT
+JIRA
+lifecycle
+MAAS
+mentorship
+MicroStack
+Multipass
+Netplan
+OpenStack
+ODA
+onboarding
+rebase
+rebasing
 repo
 repos
+PRs
+RST
+scalable
+Snapcraft
+WSL
 

--- a/website/.readthedocs.yaml
+++ b/website/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
 sphinx:
   builder: dirhtml
   configuration: website/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:

--- a/website/conf.py
+++ b/website/conf.py
@@ -186,7 +186,10 @@ redirects = {}
 #
 # TODO: Remove or adjust the ACME entry after you update the contributing guide
 
-linkcheck_ignore = ["http://127.0.0.1:8000", "https://github.com/canonical/ACME/*"]
+linkcheck_ignore = [
+    "http://127.0.0.1:8000",
+    "https://matrix.to/#/#documentation:ubuntu.com",
+]
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/website/docs/explanation/about.md
+++ b/website/docs/explanation/about.md
@@ -47,14 +47,14 @@ Anyone is welcome to participate, and that doesn't always mean working on docume
 
 ## Stay in touch
 
-If you’d like to ask us questions outside of our public forums, feel free to email us at docsacademy@canonical.com.
+If you’d like to ask us questions outside of our public forums, feel free to email us at [docsacademy@canonical.com](mailto:docsacademy@canonical.com).
 
-Subscribe to our calendar: [Documentation events](https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+You can also:
 
-Participate in our discussion forum here on the Ubuntu Community Hub:
-[https://discourse.ubuntu.com/c/community/open-documentation-academy/166](https://discourse.ubuntu.com/c/community/open-documentation-academy/166).
+* Subscribe to our calendar for [documentation events](https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
 
-Chat to us on Matrix at [https://matrix.to/#/#documentation:ubuntu.com](https://matrix.to/#/#documentation:ubuntu.com).
+* Participate in our [discussion forum here on the Ubuntu Community Hub](https://discourse.ubuntu.com/c/community/open-documentation-academy/166).
 
-Follow our progress online through Mastodon:
-[https://fosstodon.org/@CanonicalDocumentation](https://fosstodon.org/@CanonicalDocumentation).
+* Chat to us on [Matrix](https://matrix.to/#/#documentation:ubuntu.com).
+
+* Follow our progress online through [Mastodon](https://fosstodon.org/@CanonicalDocumentation).

--- a/website/docs/explanation/motivation.md
+++ b/website/docs/explanation/motivation.md
@@ -1,3 +1,0 @@
-# Motivation
-
-

--- a/website/docs/howto/get-started/index.md
+++ b/website/docs/howto/get-started/index.md
@@ -34,7 +34,7 @@ To create and then open an empty file, if you use `code <file name>` directly wi
 
 If you're using a Windows machine, start by following these instructions:
 
-- [Set up WSL on Windows](start_with_WSL).
+- [Set up WSL on Windows](using_wsl.md).
 
 If you are working on a project that uses Sphinx to render the documentation, continue with:
   

--- a/website/docs/howto/get-started/troubleshooting.md
+++ b/website/docs/howto/get-started/troubleshooting.md
@@ -27,4 +27,4 @@ If the `wsl --install` command returns the message "This operation timed out", y
     ```shell
     wsl --set-default-version 2
     ```
-5. Once you have completed the above steps, open your Microsoft Store and search for "Ubuntu". It's advisable to install the latest version. After the installation, you should launch the app. It'll automatically connect to your WSL and you should be able to follow the [next steps](./start_with_WSL.md) without errors.
+5. Once you have completed the above steps, open your Microsoft Store and search for "Ubuntu". It's advisable to install the latest version. After the installation, you should launch the app. It'll automatically connect to your WSL and you should be able to follow the [next steps](using_wsl.md) without errors.

--- a/website/docs/howto/get-started/using_git.md
+++ b/website/docs/howto/get-started/using_git.md
@@ -344,7 +344,7 @@ To make sure your branch is up to date with the remote branch, then switch to th
 git checkout main
 ```
 
-Then, you can use `git branch` to double check the name of the branch (and to confirm that you're on the main branch!), then delete your PR's branch with:
+Then, you can use `git branch` to double check the name of the branch (and to confirm that you're on the main branch!), then delete the branch for your PR with:
 
 ```bash
 git branch -d <your branch name>

--- a/website/docs/howto/get-started/using_wsl.md
+++ b/website/docs/howto/get-started/using_wsl.md
@@ -56,4 +56,4 @@ Using `sudo` will prompt you for a password. This is the same password you enter
 
 When asked if you want to continue, type `y` (not case sensitive).
 
-You're now ready to move on to the next stage! [Install and configure git](install_git.md).
+You're now ready to move on to the next stage! [Install and configure git](using_git.md).

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -7,8 +7,8 @@ issues to new contributors.
 <!-- NOTE: the grid can be adjusted to a standard 2-by-2 if we have a fourth section -->
 ````{grid} 1 1 2 2
 
-```{grid-item-card} [Tutorials](tutorial/index)
-:link: tutorial/index
+```{grid-item-card} [Tutorials](index)
+:link: index
 :link-type: doc
 
 **Tutorials** contributing to open-source documentation through the Academy
@@ -46,7 +46,7 @@ issues to new contributors.
 :hidden:
 :maxdepth: 2
 
-Tutorials <tutorial/index>
+Tutorials <self>
 How-to guides <howto/index>
 Explanation <explanation/index>
 Reference <reference/index>

--- a/website/events.md
+++ b/website/events.md
@@ -18,38 +18,38 @@ We record our Community Hour meeting if there's a presentation or a session we t
 
 |Date | Presenters | Demo / discussion and YouTube link|
 |--- | --- | ---|
-|01/03/24 | Graham | [Introduction to the Academy and team](https://www.youtube.com/watch?v=GT03aSdabJE)|
-|08/03/24 | Graham | [git and GitHub workflow demo](https://www.youtube.com/watch?v=EwRaJ_tyJ-k)|
-|15/03/24 | Graham, Robert | [GitHub UI and git user interfaces](https://www.youtube.com/watch?v=Vk5blPpwOGM)|
-|22/03/24 | Robert | [Free beer vs Freedom](https://www.youtube.com/watch?v=X5GfBMkQoy0)|
-|29/03/24 | Graham | [Text editor roundup](https://www.youtube.com/watch?v=Xc-_Uu6asgA)|
-|05/04/24 | Andreia, Robert | [Documentation testing and frameworks](https://www.youtube.com/watch?v=hoaI9RTvano)|
-|12/04/24 | Graham, Robert | [Authoring frameworks and markup languages](https://www.youtube.com/watch?v=9jijpeUMzP0)|
-|19/04/24 | Graham | [Closed task review and new task overview](https://www.youtube.com/watch?v=lwrc3u2-g2s)|
-|26/04/24 | Graham | [JIRA for task management](https://www.youtube.com/watch?v=vryGy5qCZBM)|
-|03/05/24 | Graham | [9 tips for better writing](https://www.youtube.com/watch?v=YQMULY0ksz0)|
-|10/05/24 | Graham, Shane, Giulia, Robert, Andreia | [Live from Madrid: QA session](https://www.youtube.com/watch?v=GWG-RekGkjo)|
-|17/05/24 | Keirthana, Graham, Nick, Andreia, Robert | [Live from Madrid: How to approach tutorials](https://www.youtube.com/watch?v=somxhyLJFa4)|
-|24/05/24 | Graham | [ Demonstration of Discourse and Sphinx docs systems]( https://www.youtube.com/watch?v=H3OK4rfKRiA )|
-|31/05/24 | Graham, Ruth, Robert, Shane and Dimple | [ What text editor do you use and why? ]( https://www.youtube.com/watch?v=5rrFfsdwsWo )|
-|07/06/24 | Robert, Artem, Ruth, Bill, Graham | [Documentation as Code](https://www.youtube.com/watch?v=AVNfH99KiME)|
-|14/06/24 | Nick, Shane, Graham | [Vale for testing documentation](https://www.youtube.com/watch?v=QpcY-UWKhxQ)|
-|21/06/24 | Artem | [Tips for getting hired as a technical writer or author](https://youtu.be/lAWWsq2JDt8)|
-|28/06/24 | Keirthana | [Technical Author or Technical Writer](https://youtu.be/udsfj1oE8Ns)|
-|05/07/24 | Everyone | [Open discussion on Artificial Intelligence (AI) and documentation](https://www.youtube.com/watch?v=SzFm0jnd0bc)|
-|12/07/24 | Shane, Nick | [10 ways to document terminal commands](https://www.youtube.com/watch?v=LwJMtk3Fbsg)|
-|19/07/24 | Keirthana | [How-to vs tutorial](https://www.youtube.com/watch?v=9Ct_vb-BK0s)|
-|26/07/24 | Robert | [Documentation and AI](https://youtu.be/S9rChUYSHk8)|
-|02/08/24 | Artem | [How to encourage engineers to write their own documentation](https://youtu.be/tj_jLv3zE6k)|
-|09/08/24 | Graham | [Technical writing anonymous: improve a document as a group](https://www.youtube.com/watch?v=kmGBdBFTl5Y)|
-|16/08/24 | Yana | [Industrial Standards and Documentation](https://www.youtube.com/watch?v=SZ4bCbCYf8Q)|
-|23/08/24 | Giulia | [The challenges of onboarding as a tech author](https://www.youtube.com/watch?v=2gAlGjQFjTY)|
-|06/09/24 | Vladimir | [Fight! Markdown vs reStructuredText vs AsciiDoc vs XML](https://www.youtube.com/watch?v=C0V0A8GGfAs)|
-|13/09/24 | Artem | [Documenting a new project](https://www.youtube.com/watch?v=l4VzYjsqUC4)|
-|20/09/24 | Christian Ehrhardt | [An engineering director's perspective on documentation](https://www.youtube.com/watch?v=2ShZxMJ26_A)|
-|27/09/24 | Yana | [Accessibility and documentation](https://www.youtube.com/watch?v=Egubho3-AM0)|
-|04/10/24 | Graham | [What we can learn from old synthesizer manuals](https://www.youtube.com/watch?v=Gpjw6PQtR3U)|
-|11/10/24 | Artem | [GitHub Actions for documentation](https://www.youtube.com/watch?v=zB2CGhGXpnc)|
-|18/10/24 | Shane | [Recipes and Software](https://www.youtube.com/watch?v=PW_gWv6OysM)|
-|06/12/24 | Teodora, Joost De Cock | [The inspiration behind freesewing.org](https://www.youtube.com/watch?v=SWyzQ3ChZ1I)|
-|13/12/24 | David Ekete | [Interactive RST and working with CODA](https://www.youtube.com/watch?v=_7pKdieSt74)|
+|01/03/24 | `Graham` | [Introduction to the Academy and team](https://www.youtube.com/watch?v=GT03aSdabJE)|
+|08/03/24 | `Graham` | [git and GitHub workflow demo](https://www.youtube.com/watch?v=EwRaJ_tyJ-k)|
+|15/03/24 | `Graham, Robert` | [GitHub UI and git user interfaces](https://www.youtube.com/watch?v=Vk5blPpwOGM)|
+|22/03/24 | `Robert` | [Free beer vs Freedom](https://www.youtube.com/watch?v=X5GfBMkQoy0)|
+|29/03/24 | `Graham` | [Text editor roundup](https://www.youtube.com/watch?v=Xc-_Uu6asgA)|
+|05/04/24 | `Andreia, Robert` | [Documentation testing and frameworks](https://www.youtube.com/watch?v=hoaI9RTvano)|
+|12/04/24 | `Graham, Robert` | [Authoring frameworks and markup languages](https://www.youtube.com/watch?v=9jijpeUMzP0)|
+|19/04/24 | `Graham` | [Closed task review and new task overview](https://www.youtube.com/watch?v=lwrc3u2-g2s)|
+|26/04/24 | `Graham` | [JIRA for task management](https://www.youtube.com/watch?v=vryGy5qCZBM)|
+|03/05/24 | `Graham` | [9 tips for better writing](https://www.youtube.com/watch?v=YQMULY0ksz0)|
+|10/05/24 | `Graham, Shane, Giulia, Robert, Andreia` | [Live from Madrid: QA session](https://www.youtube.com/watch?v=GWG-RekGkjo)|
+|17/05/24 | `Keirthana, Graham, Nick, Andreia, Robert` | [Live from Madrid: How to approach tutorials](https://www.youtube.com/watch?v=somxhyLJFa4)|
+|24/05/24 | `Graham` | [ Demonstration of Discourse and Sphinx docs systems]( https://www.youtube.com/watch?v=H3OK4rfKRiA )|
+|31/05/24 | `Graham, Ruth, Robert, Shane and Dimple` | [ What text editor do you use and why? ]( https://www.youtube.com/watch?v=5rrFfsdwsWo )|
+|07/06/24 | `Robert, Artem, Ruth, Bill, Graham` | [Documentation as Code](https://www.youtube.com/watch?v=AVNfH99KiME)|
+|14/06/24 | `Nick, Shane, Graham` | [Vale for testing documentation](https://www.youtube.com/watch?v=QpcY-UWKhxQ)|
+|21/06/24 | `Artem` | [Tips for getting hired as a technical writer or author](https://youtu.be/lAWWsq2JDt8)|
+|28/06/24 | `Keirthana` | [Technical Author or Technical Writer](https://youtu.be/udsfj1oE8Ns)|
+|05/07/24 | `Everyone` | [Open discussion on Artificial Intelligence (AI) and documentation](https://www.youtube.com/watch?v=SzFm0jnd0bc)|
+|12/07/24 | `Shane, Nick` | [10 ways to document terminal commands](https://www.youtube.com/watch?v=LwJMtk3Fbsg)|
+|19/07/24 | `Keirthana` | [How-to vs tutorial](https://www.youtube.com/watch?v=9Ct_vb-BK0s)|
+|26/07/24 | `Robert` | [Documentation and AI](https://youtu.be/S9rChUYSHk8)|
+|02/08/24 | `Artem` | [How to encourage engineers to write their own documentation](https://youtu.be/tj_jLv3zE6k)|
+|09/08/24 | `Graham` | [Technical writing anonymous: improve a document as a group](https://www.youtube.com/watch?v=kmGBdBFTl5Y)|
+|16/08/24 | `Yana` | [Industrial Standards and Documentation](https://www.youtube.com/watch?v=SZ4bCbCYf8Q)|
+|23/08/24 | `Giulia` | [The challenges of onboarding as a tech author](https://www.youtube.com/watch?v=2gAlGjQFjTY)|
+|06/09/24 | `Vladimir` | [Fight! Markdown vs reStructuredText vs AsciiDoc vs XML](https://www.youtube.com/watch?v=C0V0A8GGfAs)|
+|13/09/24 | `Artem` | [Documenting a new project](https://www.youtube.com/watch?v=l4VzYjsqUC4)|
+|20/09/24 | `Christian Ehrhardt` | [An engineering director's perspective on documentation](https://www.youtube.com/watch?v=2ShZxMJ26_A)|
+|27/09/24 | `Yana` | [Accessibility and documentation](https://www.youtube.com/watch?v=Egubho3-AM0)|
+|04/10/24 | `Graham` | [What we can learn from old synthesizer manuals](https://www.youtube.com/watch?v=Gpjw6PQtR3U)|
+|11/10/24 | `Artem` | [GitHub Actions for documentation](https://www.youtube.com/watch?v=zB2CGhGXpnc)|
+|18/10/24 | `Shane` | [Recipes and Software](https://www.youtube.com/watch?v=PW_gWv6OysM)|
+|06/12/24 | `Teodora, Joost De Cock` | [The inspiration behind freesewing.org](https://www.youtube.com/watch?v=SWyzQ3ChZ1I)|
+|13/12/24 | `David Ekete` | [Interactive RST and working with CODA](https://www.youtube.com/watch?v=_7pKdieSt74)|

--- a/website/index.md
+++ b/website/index.md
@@ -29,7 +29,8 @@ The Open Documentation Academy is an open source project that welcomes community
 * [How to get support](https://ubuntu.com/support/community-support)
 * [Join the Discourse forum](https://discourse.ubuntu.com/c/community/open-documentation-academy/166)
 * [Interactive chat on Matrix.org](https://matrix.to/#/#documentation:ubuntu.com)
-* [Community engagement commitment](explanation/community-engagement)
+<!-- TODO: create this file or delete the link -->
+<!-- * [Community engagement commitment](explanation/community-engagement) -->
 
 ![Open Documentation Academy booth](https://assets.ubuntu.com/v1/1a3c2549-20250218_0001_01.jpg)
 The Open Documentation Academy is sponsored by [Canonical Ltd](https://canonical.com/).

--- a/website/library/index.md
+++ b/website/library/index.md
@@ -1,5 +1,54 @@
 # Writing resources
 
+General writing tips, advice and principles.
+
+````{grid} 1 1 2 2
+
+```{grid-item-card} [Tutorials](index)
+:link: index
+:link-type: doc
+
+**Tutorials** contributing to open-source documentation through the Academy
+```
+
+
+```{grid-item-card} [How-to guides](howto/index)
+:link: howto/index
+:link-type: doc
+
+**Step-by-step guides** for working with with the most common tools and processes
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](reference/index)
+:link: reference/index
+:link-type: doc
+
+**Information and resources** for contributors and for technical writers
+```
+
+```{grid-item-card} [Explanation](explanation/index)
+:link: explanation/index
+:link-type: doc
+
+**Explanations** of key concepts, tools and processes
+```
+
+````
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+Tutorials <self>
+How-to guides <howto/index>
+Explanation <explanation/index>
+Reference <reference/index>
+
+```
 
 ```{toctree}
 :hidden:

--- a/website/projects.md
+++ b/website/projects.md
@@ -17,7 +17,7 @@ The first words of an issue's title will typically indicate the project it invol
 -   [Our Sphinx and RST starter pack](https://github.com/canonical/sphinx-docs-starter-pack): our open source template for building modern documentation
 -   [Snap and Snapcraft](https://snapcraft.io/docs): Linux app packages and the build tools for desktop, cloud and IoT
 -   [Ubuntu Developer Guide](https://github.com/canonical/ubuntu-for-developers-docs): guide for developers using Ubuntu Desktop as a development platform
--   [ubuntu-image](https://github.com/canonical/ubuntu-image): Tool for generating bootable Ubuntu images
+-   [`ubuntu-image`](https://github.com/canonical/ubuntu-image): Tool for generating bootable Ubuntu images
 -   [Ubuntu on public cloud](https://documentation.ubuntu.com/public-cloud/en/latest/): Optimised Ubuntu images for partner clouds
 -   [Ubuntu Packaging Guide](https://github.com/canonical/ubuntu-packaging-guide): manual for Ubuntu package maintainers
 -   [Ubuntu Server documentation](https://github.com/canonical/ubuntu-server-documentation): Official documentation for the Ubuntu Server distribution

--- a/website/release-notes.md
+++ b/website/release-notes.md
@@ -2,4 +2,4 @@
 
 _What's new in the Open Documentation Academy_
 
-**28th February 2025** Our first version of the proposed Documentation Academy website has gone live. This is more of a prototype than a final design, but we want to work on this as a collaborative effort with the community.
+**February 28, 2025** Our first version of the proposed Documentation Academy website has gone live. This is more of a prototype than a final design, but we want to work on this as a collaborative effort with the community.

--- a/website/resources.md
+++ b/website/resources.md
@@ -1,1 +1,0 @@
-# Resources


### PR DESCRIPTION
A recent PR https://github.com/canonical/open-documentation-academy/pull/176 introduced some major changes to the structure of the CODA website/documentation.

This fixes various build errors associated with those changes.

The RTD settings were updated in the RTD dashboard so build previews for PRs now also work.