### PR TITLE
add Ubuntu Desktop to CODA

### DIFF
--- a/ubuntu-desktop/README.md
+++ b/ubuntu-desktop/README.md
@@ -1,0 +1,33 @@
+For over 20 years, the Ubuntu Linux desktop has been one of the most popular
+Linux distributions, and the gateway to Linux and open source for millions of
+users. Its success has always been due to a tight collaboration between the
+Ubuntu community and Canonical, and the documentation that accompanies each and
+every release.
+
+The Ubuntu Desktop documentation, however, is showing signs of its age. Many
+users find that it's spread across too many different locations. Topics can be
+difficult to find, difficult to follow, and sometimes out-of-date. To help
+solve these problems, Canonical is in the very early stages of prototyping a
+new platform that we hope will be the foundation for the Ubuntu Desktop
+documentation for the next 20 years, and beyond. This represents a wonderful
+and exciting opportunity for the Open Documentation Academy, both in supporting
+and following what should become a trailblazing documentation platform, and
+also in seeding a set of open source community documentation for the next
+generation of Ubuntu users.
+
+To start with, several issues related to Desktop will be added to CODA. You can
+think of them all as top-level guides, suitable for a beginner who is curious
+to know more, but also pointing at more technical content that an advanced user
+might pursue further (perhaps these are future CODA issues too). They're broad
+because we want to invoke the more creative side of technical writing. Many of
+your readers will be ordinary users, and their skill levels (and patience) will
+vary hugely.
+
+This is an excellent opportunity to get involved at the beginning of what we
+hope will be a major project to improve Desktop documentation in the coming
+years. The initial topics that we have selected will give you opportunities to
+stretch your writing muscles in new ways, often requiring you to connect ideas
+and explain them for the general user
+
+To get started, just take a look for tasks with the 'desktop' label in our task
+tracker.


### PR DESCRIPTION
Intially, for the as-yet-unpublished new Ubuntu Desktop docs.