### PR TITLE
CODA website: Transclude the list of projects from the root README.md file of the Open Documentation Academy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Issues are identified and shared by participating projects at Canonical who cont
 
 ### Participating projects
 
+<!-- start-participating-projects -->
 The first words of an issue's title will typically indicate the project it involved. These include the following:
 
 - [ADSys](https://documentation.ubuntu.com/adsys/en/stable/): Active Directory Group Policy client for Ubuntu
@@ -44,6 +45,7 @@ The first words of an issue's title will typically indicate the project it invol
 - [Ubuntu WSL](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/): Ubuntu terminal environment on Windows with the Windows Subsystem for Linux (WSL)
 
 This list will expand as more projects get involved. We're also happy to include projects outside of Canonical.
+<!-- end-participating-projects -->
 
 ### Contributor licence agreement
 

--- a/website/projects.md
+++ b/website/projects.md
@@ -1,28 +1,10 @@
 # Participating projects
 
-The first words of an issue's title will typically indicate the project it involved. These include the following:
+<!-- Includes participating projects from the root README.md of the Open Documentation Academy repository. -->
+<!-- Don't edit this file directly. -->
+<!-- To update the project list, edit the "Participating projects" section in the root README.md: https://github.com/canonical/open-documentation-academy/blob/main/README.md -->
 
-- [ADSys](https://documentation.ubuntu.com/adsys/en/stable/): Active Directory Group Policy client for Ubuntu
-- [Anbox Cloud](https://anbox-cloud.io/docs): Solution offering scalable Android in the cloud
-- [authd](https://documentation.ubuntu.com/authd/stable/): authentication service for Ubuntu that integrates with cloud identity providers
-- [Canonical Kubernetes](https://ubuntu.com/kubernetes/docs): the reference platform for Kubernetes on all major public clouds
-- [Charmed OpenStack](https://ubuntu.com/openstack/docs): our traditional enterprise cloud solution
-- [Juju](https://juju.is/docs): open source orchestration engine
-- [LXD](https://documentation.ubuntu.com/lxd/en/latest/): open source container and VM management at any scale
-- [Landscape](https://ubuntu.com/landscape/docs): Ubuntu systems management, monitoring and administration platform
-- [Launchpad](https://documentation.ubuntu.com/launchpad/en/latest/): software development lifecycle and collaboration platform
-- [MAAS](https://maas.io/docs): bare metal cloud with on-demand servers
-- [MicroCeph](https://canonical-microceph.readthedocs-hosted.com/en/squid-stable/): the easiest way to get up and running with Ceph
-- [MicroStack](https://microstack.run/docs): our next generation enterprise cloud solution
-- [Multipass](https://discourse.ubuntu.com/t/multipass-documentation/8294): tool to generate cloud-style Ubuntu virtual machines
-- [Netplan](https://github.com/canonical/netplan): network configuration for various backends
-- [Our Sphinx and RST starter pack](https://github.com/canonical/sphinx-docs-starter-pack): our open source template for building modern documentation
-- [Snap and Snapcraft](https://snapcraft.io/docs): Linux app packages and the build tools for desktop, cloud and IoT
-- [Ubuntu Developer Guide](https://github.com/canonical/ubuntu-for-developers-docs): guide for developers using Ubuntu Desktop as a development platform
-- [`ubuntu-image`](https://github.com/canonical/ubuntu-image): Tool for generating bootable Ubuntu images
-- [Ubuntu on public cloud](https://documentation.ubuntu.com/public-cloud/en/latest/): Optimised Ubuntu images for partner clouds
-- [Ubuntu Packaging Guide](https://github.com/canonical/ubuntu-packaging-guide): manual for Ubuntu package maintainers
-- [Ubuntu Server documentation](https://github.com/canonical/ubuntu-server-documentation): Official documentation for the Ubuntu Server distribution
-- [Ubuntu WSL](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/): Ubuntu terminal environment on Windows with the Windows Subsystem for Linux (WSL)
-
-This list will expand as more projects get involved. We're also happy to include projects outside of Canonical.
+```{include} ../README.md
+:start-after: <!-- start-participating-projects -->
+:end-before: <!-- end-participating-projects -->
+```


### PR DESCRIPTION
In line with the suggestion in issue #259, this PR updates the website/projects.md file to include the participating projects section from the root README.md file.

I used the MyST {include} directive to pull the content directly. The README.md now contains clear markers to define the start and end of the section. This ensures both files stay in sync and reduces duplication.