### PR TITLE
Fixed the navigation bar and logo issue

### DIFF
--- a/website/.sphinx/_static/css/header.css
+++ b/website/.sphinx/_static/css/header.css
@@ -1,0 +1,33 @@
+/* Fix the odd looking navigation link (More Resources) on big screens */
+ul.p-navigation__links {
+  max-width: unset !important;
+}
+
+/* Work around to make the logo look better on small devices */
+@media (max-width: 550px) {
+  .p-logo-text {
+    color: transparent;
+    position: relative;
+  }
+  .p-logo-text::after {
+    content: "CODA";
+    position: absolute;
+    top: 0;
+    left: 0;
+    color:white;
+  }
+}
+
+/* Hide the unwanted empty link inside the header for small devices */
+@media (max-width: 800px) {
+  .nav-ubuntu-com {
+    display: none;
+  }
+}
+
+/* Add margin to the right side of the header to improve UI */
+@media only screen and (min-width: 1310px) {
+    ul.p-navigation__links {
+        margin-right: calc(50% - 41em);
+    }
+}

--- a/website/conf.py
+++ b/website/conf.py
@@ -250,6 +250,7 @@ exclude_patterns = [
 
 html_css_files = [
     "css/pdf.css",
+    "css/header.css",
     # For short-term announcement about survey
     # TODO: Remove this block by 2025-08-11
     "css/announcement.css",


### PR DESCRIPTION
Fix for: [Website: Header cuts off the ODA text](https://github.com/canonical/open-documentation-academy/issues/226#top) 
Created a new Header.css file to fix issues related to header and logo. Added various styles to fix the navigation and logo appearance on both big and small screens. Implement a work around for the logo text to make it look better on small screens.