### PR TITLE
Set up Charmed Ceph content for contribution

### DIFF
--- a/charmed-ceph/contribute.md
+++ b/charmed-ceph/contribute.md
@@ -1,0 +1,214 @@
+Contributing to documentation is a great way to get started as a contributor to open-source projects, no matter your level of experience.
+
+We welcome, encourage and appreciate contributions from our user community in the form of suggestions, fixes and constructive feedback. Whether you are new to Ceph and want to highlight something you found confusing, or you’re an expert and want to create a “how-to” guide to help others, we will be happy to work with you to make our documentation better for everybody.
+
+Leave a comment on the Discourse forum post or talk to us on our [Matrix](https://app.element.io/#/room/#ceph-general:ubuntu.com) channel.
+
+We hope to make it as easy as possible to contribute. If you feel something is unclear, wrong, or broken, please don’t hesitate to leave a comment in the Matrix room.
+
+## Editing on Discourse
+
+The Charmed Ceph documentation is published via our [Discourse forum](https://discourse.ubuntu.com/c/ceph/52) hosted at [https://discourse.ubuntu.com/](https://discourse.ubuntu.com/).
+
+Every documentation page is published from an equivalent [`doc` category](https://discourse.ubuntu.com/c/documentation/ceph-docs/53) forum post. Each forum post can be accessed from the [Help improve this document in the forum](https://discourse.ubuntu.com/c/ceph/docs/53) link at the bottom of every page of our documentation.
+
+Feel free to improve any documentation topic; pages are freely editable within the forum itself. Just click on the *Edit* button at the bottom of the documentation article forum post:
+
+![image|220x34](upload://fHKL570wWLOZKne155Fsp3UxSHK.png)
+
+
+Documentation is written in the [Markdown](https://daringfireball.net/projects/markdown/syntax) format [supported by Discourse](https://meta.discourse.org/t/post-format-reference-documentation/19197/2).
+
+Mostly, you don’t need to worry about the syntax. You can simply use the style toolbar in the Discourse topic editing window to mark the elements you need.
+
+### New users
+
+If you are a new Discourse user, your capabilities will be temporarily limited. Discourse uses a trust system that grants experienced users more rights over time. New users start at Trust Level 0, but quickly get to Trust Level 1 where all new user restrictions are removed and they can create and edit our documentation freely. 
+
+Trust Level 1 is attained by:
+
+* Entering at least 5 topics  
+* Reading at least 30 posts  
+* Spending a total of 10 minutes reading posts
+
+Users at Trust Level 1 can:
+
+* Edit wiki posts  
+* Use all core Discourse functions; all new user restrictions are removed  
+* Send private messages  
+* Upload images and attachments  
+* Flag posts to alert moderators  
+* Mute other users
+
+## Diátaxis
+
+Our documentation content, style and navigational structure follows the [Diátaxis](https://diataxis.fr/) systematic framework for technical documentation authoring. This framework splits documentation pages into tutorials, how-to guides, reference material and explanatory text:
+
+* **Tutorials** are lessons that accomplish specific tasks through *doing*. They help with familiarity and place users in the safe hands of an instructor.  
+* **How-to guides** are recipes, showing users how to achieve something, helping them get something done. A *How-to* has no obligation to teach.  
+* **Reference** material is descriptive, providing facts about functionality that is isolated from what needs to be done.  
+* **Explanation** is discussion, helping users gain a deeper or better understanding of Charmed Ceph, as well as how and why Charmed Ceph functions as it does.
+
+To learn more about our Diátaxis strategy, see [Diátaxis, a new foundation for Canonical documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
+
+Improving our documentation and applying the principles of Diátaxis are on-going tasks. There’s a lot to do, and we don’t want to deter anyone from contributing to our docs. If you don’t know whether something should be a tutorial, how-to, reference doc or explanatory text, either ask on the forum or publish in the category you think is best. Changes are easy to make, and every contribution helps.
+
+## Open Documentation Academy
+
+Charmed Ceph is a proud member of the [Canonical Open Documentation Academy](https://github.com/canonical/open-documentation-academy) (CODA), an initiative led by the documentation team at Canonical to provide help, advice, mentorship, and dozens of different tasks to get started on, within a friendly and encouraging environment.
+
+A key aim of this initiative is to help lower the barrier into successful open-source software contribution, by making documentation into the gateway, and it’s a great way to make your first open source documentation contributions to Charmed Ceph.
+
+But even if you’re an expert, we want the academy to be a place to share knowledge, a place to get involved with new developments, and somewhere you can ask for help on your own projects.
+
+The best way to get started is with our [task list](https://github.com/canonical/open-documentation-academy/issues) . Take a look, bookmark it, and see our [Getting started](https://discourse.ubuntu.com/t/getting-started/42769) guide for next steps.
+
+Stay in touch either through the task list, or through one of the following locations:
+
+* Our [discussion forum](https://discourse.ubuntu.com/c/open-documentation-academy) on the Ubuntu Community Hub.  
+* In the [Matrix](https://matrix.to/#/#documentation:ubuntu.com) room for interactive chat.  
+* [Follow us on Fosstodon](https://fosstodon.org/@CanonicalDocumentation) for the latest updates and events.
+
+If you’d like to ask us questions outside of our public forums, feel free to email us at docsacademy@canonical.com.
+
+In addition to the above, we have a weekly Community Hour starting at 16:00 UTC every Friday. Everyone is welcome, and links and comments can be found on the [forum post](https://discourse.ubuntu.com/t/documentation-office-hours/42771).
+
+Finally, subscribe to our [Documentation event calendar](https://calendar.google.com/calendar/u/0?cid=Y19mYTY4YzE5YWEwY2Y4YWE1ZWNkNzMyNjZmNmM0ZDllOTRhNTIwNTNjODc1ZjM2ZmQ3Y2MwNTQ0MzliOTIzZjMzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20). We’ll expand our Community Hour schedule and add other events throughout the year.
+
+### Agreements
+
+Everyone involved with CODA needs to follow the words and spirit of the [Ubuntu Code of Conduct v2.0](https://ubuntu.com/community/ethos/code-of-conduct). By participating, you implicitly agree to abide by this code of conduct.
+
+If this is the first time you are contributing to a Canonical project, you will need to sign the [Canonical Contributor Licence Agreement](https://ubuntu.com/legal/contributors) before your contribution can be considered for inclusion within our project. If you have already signed it, e.g. when contributing to another Canonical project, you do not need to sign it again.
+
+This licence protects your copyright over your contributions, including the right to use them elsewhere, but grants us (Canonical) permission to use them in our project.
+
+### Identifying suitable task
+
+The academy uses issue labels to give the contributor a glimpse into the task and what it requires, including the type of task, skills or level of expertise required, and even the size estimation for the task. You can find tasks of all sizes in the academy issues list.
+
+From small tasks, such as replacing outdated terminology, checking for broken links, testing a tutorial or ensuring adherence to the [Canonical documentation style guide](https://docs.ubuntu.com/styleguide/en); to medium-sized  tasks like, converting documentation from one format to another, or migrating the contents of a blog post into the official documentation; to more ambitious tasks, such as adding a new *How-to* guide, restructuring a group of documents, or developing new tests and automations.
+
+### Completing and closing tasks
+
+When a task has been completed to your satisfaction, we’ll ask the contributor whether they would prefer to merge their work into your project themselves, or leave this to the project.
+
+### Recognition
+
+After successfully completing a task, we’ll give credit to the contributor and share their success in our forums, on the pages themselves, and in our news updates and release notes.
+
+## Guidance for writing
+
+Consistency of writing style in documentation is vital for a good user experience. To accommodate our audience with a huge variation in experience, we:
+
+* write with our target audience in mind  
+* write inclusively and assume very little prior knowledge of the reader  
+* link or explain phrases, acronyms and concepts that may be unfamiliar, and if unsure, err on the side of caution  
+* adhere to the style guide
+
+### Language
+
+Canonical previously used British (GB) English, so you may notice that older documentation is in this format. However, we have recently switched to US English. It's a good idea to set your spellchecker to `en-US`; which will pick up most of of the inconsistencies. If it doesn't, they will be picked up in review by the documentation team.
+
+There are many small differences between UK and US English, but for the most part, it comes down to spelling.
+Some common differences are:
+
+* the *ize* suffix in preference to *ise* (e.g. capitalize rather than capitalise)  
+* *our* instead of *or* (as in color and colour)  
+* licence as both a verb and noun  
+* catalog rather than catalogue
+* dates take the format 1 January 2013, 1-2 January 2025 and 1 January \- 2 February 2025
+
+### Acronyms
+
+Acronyms should always be capitalized.
+
+They should always be expanded the first time they appear on a page, and then can be used as acronyms after that. E.g. OSD should be shown as Object Storage Daemon (OSD), and then can be referred to as OSD for the rest of the page.
+
+### Links
+
+The first time you refer to a package or other product, you should make it a link to either that product’s website, or its documentation, or its manpage.
+
+Links should be from reputable sources (such as official upstream docs). Try not to include blog posts as references if possible. And, always verify that the links are correct and accurate.
+
+Try to use  inline links sparingly. If you have a lot of useful references you think the reader might be interested in, feel free to include a “Further reading” section at the end of the page.
+
+### Writing style
+
+Try to be concise and to-the-point in your writing.
+
+It’s alright to be a bit light-hearted and playful in your writing, but please keep it respectful, and don’t use emoji (they don’t render well in documentation, and may not be deemed professional).
+
+It’s also good practice not to assume that your reader will have the same knowledge as you. If you’re covering a new topic (or something complicated) then try to briefly explain, or link to supporting explanations of, the things the typical reader may not know, but needs to (refer to the Diátaxis framework to help you decide what type of documentation you are writing and the level and type of information you need to include, e.g. a tutorial may require additional context but a how-to guide can skip some foundational knowledge \- it is safer to assume some prior knowledge).
+
+## Markdown elements
+
+### Sections and headings
+
+Avoid skipping header levels in your document structure, i.e., a level 2 header (##) should be followed by a level 3 sub-header (###) not level 4.
+
+```
+# Heading level 1
+
+## Heading level 2
+
+### Heading level 3
+
+#### Heading level 4
+```
+
+Always include some text between headers if you can. You can see this demonstrated between this section’s heading and the one above it (Markdown elements). It looks quite odd without text to break the headers apart!
+
+### Lists
+
+For a numbered list, use 1. in front of each item. The numbering will be automatically rendered, so it makes it easier for you to insert new items in the list without having to re-number them all:
+
+```
+1. This is the first item
+
+1. This is the second
+
+1. This is the third
+```
+
+Unless a list item includes punctuation, don’t end it with a full stop. If one item in a list needs a full stop, add one to all the items in that list.
+
+### Code blocks
+
+Enclose a code block with three backticks:
+
+```text
+
+  ```yaml
+
+  Some code block here
+```
+```
+```
+
+
+Use separate command input blocks from command output blocks. We do this because we have a “copy to clipboard” feature in the documentation, and it’s more convenient for the reader to copy the code if it only contains the input.
+
+Avoid using a command line prompt (e.g. $ or #) in an input block if possible, and precede the output block with some kind of text that explains what’s happening. For example:
+
+```bash
+
+Juju list models
+
+```
+
+Produces the following output:
+
+```text
+
+Model     	Cloud/Region     	Type  Status 	Machines  Units  Access  Last connection
+
+ceph-charms\*  localhost/localhost  lxd   available     	3  	3  admin   15 minutes ago
+
+controller	localhost/localhost  lxd   available     	1  	1  admin   just now
+
+```
+
+It can also be helpful to orient the reader with what they should be seeing if you can include examples.
+
+Use a single backtick to mark inline commands and other string literals, like `paths/to/files`.

--- a/charmed-ceph/explanation.md
+++ b/charmed-ceph/explanation.md
@@ -1,0 +1,28 @@
+This section provides explanatory and conceptual guides as well as a technical background on topics. It is meant to help you expand your knowledge of the Ceph ecosystem.
+
+## Storage types
+
+Ceph provides object, block, and file based storage on commodity hardware.
+
+* [Object storage](/t/18819)
+* [Block storage](/t/18821)
+* [File storage](/t/18818)
+
+## Pool types
+
+Pools constitute the basic building blocks of a Ceph cluster. They allow for high level organisation of data into logical storage areas, where each is defined by a number of properties (e.g. quantity of Placement Groups, CRUSH rules, resiliency factor). A pool can be one of two types:
+
+* [Replicated pools](/t/18805)
+* [Erasure-coded pools](/t/18807)
+
+## RADOS Gateway multi-site replication
+
+Charmed Ceph supports multi-site replication with the Ceph RADOS Gateway. This provides even more resilience to your object storage by replicating it to geographically separated Ceph clusters. This is of particular importance for active backup and disaster recovery scenarios where a site is compromised and access to data would be otherwise lost.
+
+ * [RADOS Gateway multi-site replication](/t/35992)
+
+## Security
+
+Learn about security topics applicable to Charmed Ceph.
+
+* [Full disk encryption](/t/68576)

--- a/charmed-ceph/how-to.md
+++ b/charmed-ceph/how-to.md
@@ -1,0 +1,40 @@
+This section contains guides to help you manage you have your already up and running Ceph cluster, taking you through the complete node lifecycle.
+
+## Installing and initialising Ceph
+
+Perform a general install of Charmed Ceph access the web UI.
+
+* [Installing Charmed Ceph](/t/charmed-ceph-manual-install/18803)
+* [Installing Ceph dashboard](/t/ceph-dashboard-install/24829)
+
+<!-- ## Node lifecycle-->
+## Managing your cluster
+To ensure the health of your cluster, you need to scale your OSDs and MONs up or down, or replace OSD disks by recreating a Ceph OSD disk within a Charmed Ceph deployment. Depending on your MAAS nodes, you may need to change your change block devices.
+
+  - [Adding OSDs](/t/18783)
+  - [Adding MONs](/t/18784)
+  - [Replacing OSD disks](/t/18788)
+  - [Removing OSDs](/t/28296)
+  - [Removing MONs](/t/27595)
+  - [Enabling full disk encryption](/t/68577)
+
+## Multi-site operations
+
+Here we discuss setting up [RADOS Gateway multi-site replication](https://ubuntu.com/ceph/docs/multi-site) in a charmed Ceph deployment. Native replication between ceph-radosgw applications is supported via `juju relations`. By default, both primary and secondary RGW applications accept write operations (i.e. active-active replication is configured).
+
+* [Setting up multi-site replication](t/setting-up-multi-site-replication/36025)
+* [Recovering from an outage with multi-site replication](t/recovering-from-an-outage-with-multi-site-replication/36026)
+* [Scaling down multi-site to single-site](t/scaling-down-multi-site-to-single-site/36027)
+
+## Upgrading deployment software
+
+There are three pieces of software in a Charmed Ceph deployment that can be upgraded:
+
+1. [charms](/t/18776)
+2. [cluster node operating system](/t/18777)
+3. [Ceph itself](/t/18778)
+
+## Contact us
+
+  - [Report security vulnerabilities](/t/68578)
+  

--- a/charmed-ceph/reference.md
+++ b/charmed-ceph/reference.md
@@ -1,0 +1,23 @@
+The reference guides in this section provide technical information you may need to reference when using Ceph. It also provides additional information about using Ceph; release information for Charmed Ceph, OpenStack charms and upstream Ceph; supported versions of Ceph, OpenStack and Ubuntu LTS releases.
+
+* [Supported versions](/t/18799)
+* [Release cycle](/t/18800)
+* [Release notes](/t/18764)
+* [Appendices](/t/30626)
+
+<!--## Supported versions
+Supported Ceph versions and their corresponding OpenStack supported versions and stable Ubuntu LTS releases.
+
+## Release notes
+Release information for Charmed Ceph and OpenStack Charms.
+
+## Release cycle
+Release schedule for Charmed Ceph and Charmed OpenStack.
+
+## Appendices
+Additional information that may be useful when using Ceph.
+
+* [Client setup](/t/18765)
+* [Charm list](/t/18766)
+* [Upgrade notes](/t/18767)
+-->

--- a/charmed-ceph/tutorial.md
+++ b/charmed-ceph/tutorial.md
@@ -1,0 +1,301 @@
+This tutorial will guide you through the process of deploying a Ceph cluster on [LXD](https://canonical.com/lxd) with [Juju](https://juju.is/). You will use Juju to pull the `ceph-mon` and `ceph-osd` charms from [Charmhub](https://charmhub.io/) and colocate them on three LXD machines. To do this, you will need to create a Juju controller on your local LXD cloud to manage your deployment. 
+
+You will then add a model to deploy your charms, and make the services deployed by these charms aware of each other using [Juju integrations](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/list-of-juju-cli-commands/integrate/).
+
+By the end of the tutorial, you will have deployed a standalone Ceph model on LXD with three nodes each containing a `ceph-osd` unit and `ceph-mon` unit, that are integrated with Juju, and you will be ready to customise your Charmed Ceph cluster even more and explore more use cases.
+
+## Prerequisites
+ 
+* A host running Ubuntu 22.04 (Jammy) or later, with:  
+  * at least 4 CPU cores  
+  * 16 GiB RAM  
+  *  90 GiB disk space  
+* An internet connection to access [charmhub](https://charmhub.io/)
+  * To verify, use `ping charmhub.io` in your terminal.
+
+## Install Juju
+
+First, install Juju as a snap package from the Snap Store.
+
+```
+sudo snap install juju
+```
+
+## Install and initialise LXD
+
+Install LXD also as a snap from the Snap Store.
+
+```
+sudo snap install lxd
+```
+
+[note type="positive" status="info"]
+If you get an error message that the LXD snap is already installed, run  `sudo snap refresh lxd` to refresh it and ensure that you are running an up-to-date version:
+[/note]
+
+Running `lxd init` starts an interactive configuration process on your terminal. Add the `--auto` flag to the command to skip the configuration steps and create a setup with default options.
+
+```
+lxd init --auto
+```
+
+## Bootstrap a Juju Controller
+
+Next, create a Juju controller to manage your Ceph deployment with the cloud name `localhost` and controller name `lxd-controller.`
+
+This process takes about 5 minutes.
+
+```
+juju bootstrap localhost lxd-controller
+```
+
+```
+Creating Juju controller "lxd-controller" on localhost/localhost
+Looking for packaged Juju agent version 3.6.3 for amd64
+Located Juju agent version 3.6.3-ubuntu-amd64 at https://streams.canonical.com/juju/tools/agent/3.6.3/juju-3.6.3-linux-amd64.tgz
+To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
+Launching controller instance(s) on localhost/localhost...
+ - juju-6f74c7-0 (arch=amd64)            	 
+Installing Juju agent on bootstrap instance
+Waiting for address
+Attempting to connect to 10.125.39.190:22
+Attempting to connect to [fd42:7fd9:2c4e:1ff8:216:3eff:fe86:5d1a]:22
+Connected to 10.125.39.190
+Running machine configuration script...
+Bootstrap agent now started
+Contacting Juju controller at 10.125.39.190 to verify accessibility...
+
+Bootstrap complete, controller "lxd-controller" is now available
+Controller machines are in the "controller" model
+
+Now you can run
+	juju add-model <model-name>
+to create a new model to deploy workloads.
+```
+
+Note that the bootstrap process creates a controller machine which will be useful for managing our Juju deployment, and places it in the controller model. 
+
+Run the following command to list all your controllers:
+
+```
+juju list-controllers
+```
+
+You will notice that a controller named `lxd-controller`, like we had specified, has been created. 
+
+Also note that we don’t have anything under “Model” because we have not created a model yet, but one model is listed under “Models”. This refers to the controller model that was automatically created during the bootstrapping process. 
+
+Your output should look something like this:
+
+```
+Use --refresh option with this command to see the latest information.
+
+Controller      Model     User       Access 	 Cloud/Region     	Models  Nodes	HA    Version	   
+lxd-controller*   -       admin      superuser   localhost/localhost   1  	  1     none   3.6.3 
+```
+
+## Add a Juju model
+
+Create a Juju model to deploy your cluster. We’ll name it `ceph-charms` because we will use it to deploy our Ceph charms, but you can name it anything memorable.
+
+```
+juju add-model ceph-charms
+```
+
+```
+Added 'ceph' model on localhost/localhost with credential 'localhost' for user 'admin'
+```
+
+List your models this way:
+
+```
+juju list-models
+```
+
+The output of the list command will show the model we just created, and the controller model. It also shows the controller on which our model is created. Notice that our model does not have any machines or units  deployed onto it yet.
+
+```
+Controller: lxd-controller
+
+Model     	Cloud/Region     	Type  Status 	Machines  Units  Access  Last connection
+ceph-charms*  localhost/localhost  lxd   available     	0  	-  admin   never connected
+controller	localhost/localhost  lxd   available     	1  	1  admin   just now
+```
+
+## Deploy your Ceph cluster
+
+We will deploy three machines and six units on the model, with two units (a `ceph-osd` and `ceph-mon` unit) colocated on each machine.
+
+### Deploy the OSD units
+
+Use Juju to deploy three `ceph-osd` units to your cluster.
+
+```
+juju deploy ch:ceph-osd -n 3 --storage osd-devices="loop,5G,1" --constraints "virt-type=virtual-machine root-disk=20G"
+```
+
+In this command, Juju pulls the `ceph-osd` charm from Charmhub, creates three virtual machines and deploys the charm on all three machines. The output will look something like this.
+
+```
+Deployed "ceph-osd" from charm-hub charm "ceph-osd", revision 622 in channel quincy/stable on ubuntu@20.04/stable
+```
+
+[note type="positive" status="info"]
+LXD machines are usually containers. However, LXD does not support adding block devices to containers.  We need to add block devices to our `ceph-osd` units, so we will use the  `-- constraints` flag to specify that we want our machines to be virtual machines, which will allow us to do this, rather than containers.
+[/note]
+
+The `--storage` flag commissions storage devices to the deployed units.  
+
+`osd-devices` is a storage option that is specific to the `ceph-osd` charm;  it is used to declare block devices that should be enrolled as OSDs automatically. It lists what block devices can be used for OSDs across the cluster. 
+
+Now, let’s run `juju list-models` again:
+
+```
+Controller: lxd-controller
+
+Model     	Cloud/Region     	Type  Status 	Machines  Units  Access  Last connection
+ceph-charms*  localhost/localhost  lxd   available     	3  	3  admin   15 minutes ago
+controller	localhost/localhost  lxd   available     	1  	1  admin   just now
+```
+
+And we’ll see that our model now contains three machines and three units.
+
+### Deploy the Monitor units
+
+Remember that three machines had been created by Juju in the previous step. We will now reuse them by collocating `ceph-mon` units with the `ceph-osd` units already on them
+
+To find the names of our deployed machines, run `juju list-machines`.
+
+```
+Machine  State	Address    	Inst id    	Base      	AZ  Message
+0    	started  10.125.39.192  juju-687c44-0  ubuntu@20.04  	Running
+1    	started  10.125.39.193  juju-687c44-1  ubuntu@20.04  	Running
+2    	started  10.125.39.191  juju-687c44-2  ubuntu@20.04  	Running
+```
+
+The output of this command shows that machines 0, 1 and 2 are running. We will use these machine numbers to make sure that the `ceph-mon` units we will deploy next are colocated on the same machines. 
+
+```
+juju deploy -n 3 --to 0,1,2 ceph-mon
+```
+
+Unlike Ceph OSD units, Ceph Monitor units don’t need block devices. Therefore, they can be stored in containers. This command will create containers on the three machines for the `ceph-mon` units.
+
+```
+Deployed "ceph-mon" from charm-hub charm "ceph-mon", revision 243 in channel quincy/stable on ubuntu@20.04/stable
+```
+
+When we run `juju list-models` again, we’ll see that we now have 3 machines and 6 units in our model, with no relations. This means that the deployed units do not know about each other.
+
+```
+Controller: lxd-controller
+
+Model    	  Cloud/Region     	  Type   Status  	Machines  Units  Access  Last connection
+ceph-charms*  localhost/localhost  lxd   available     3  	    6    admin   30 minutes ago
+controller    localhost/localhost  lxd   available     1  	    1    admin   just now
+```
+
+### Connect the OSD and Monitor units together
+
+We need the `ceph-osd` and `ceph-mon` services to know about each other. Since the units are already on the same model, it is easy to integrate them using Juju.
+
+```
+juju integrate ceph-osd:mon ceph-mon:osd
+```
+
+### Monitor the deployment
+
+Check the status of your model, including the machines and units in it . Use the `--watch` flag and specify `2s` to automatically refresh the status of the model after every two seconds.
+
+```
+juju status --watch 2s
+```
+
+Wait and watch the model stabilise. The output should look something like this:
+
+```
+Model  Controller  	Cloud/Region     	Version  SLA      	Timestamp
+ceph-charms   lxd-controller  localhost/localhost  3.6.3	unsupported  15:32:25+03:00
+
+App   	Version  Status   	Scale  Charm 	Channel    	Rev  Exposed  Message
+ceph-mon       	maintenance	2/3  ceph-mon  quincy/stable  243  no   	installing charm software
+ceph-osd       	maintenance	1/3  ceph-osd  quincy/stable  622  no   	installing charm software
+
+Unit     	Workload 	Agent   	Machine  Public address                      	Ports  Message
+ceph-mon/0   maintenance  executing   0    	fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2     	(install) installing charm software
+ceph-mon/1*  waiting  	allocating  1    	fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809     	agent initialising
+ceph-mon/2   maintenance  executing   2    	fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999     	(install) installing charm software
+ceph-osd/0   waiting  	allocating  0    	fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2     	agent initialising
+ceph-osd/1*  maintenance  executing   1    	fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809     	(install) installing charm software
+ceph-osd/2   waiting  	allocating  2    	fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999     	agent initialising
+
+Machine  State	Address                             	Inst id    	Base      	AZ  Message
+0    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2  juju-cbc3a3-0  ubuntu@20.04  	Running
+1    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809  juju-cbc3a3-1  ubuntu@20.04  	Running
+2    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999  juju-cbc3a3-2  ubuntu@20.04  	Running
+```
+
+Once stabilised, the units in your model should be in active/idle state, and the machines should all be running. Observe that the Ceph OSD and Monitor units were indeed colocated on machines `0`, `1` and `2`.
+
+```
+Model  Controller  	Cloud/Region     	Version  SLA      	Timestamp
+ceph   lxd-controller  localhost/localhost  3.6.3	unsupported  15:50:10+03:00
+
+App   	Version  Status  Scale  Charm 	Channel    	Rev  Exposed  Message
+ceph-mon  17.2.7   active  	3  ceph-mon  quincy/stable  243  no   	Unit is ready and clustered
+ceph-osd  17.2.7   active  	3  ceph-osd  quincy/stable  622  no   	Unit is ready (1 OSD)
+
+Unit     	Workload  Agent  Machine  Public address                      	Ports  Message
+ceph-mon/0   active	idle   0    	fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2     	Unit is ready and clustered
+ceph-mon/1*  active	idle   1    	fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809     	Unit is ready and clustered
+ceph-mon/2   active	idle   2    	fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999     	Unit is ready and clustered
+ceph-osd/0   active	idle   0    	fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2     	Unit is ready (1 OSD)
+ceph-osd/1*  active	idle   1    	fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809     	Unit is ready (1 OSD)
+ceph-osd/2   active	idle   2    	fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999     	Unit is ready (1 OSD)
+
+Machine  State	Address                             	Inst id    	Base      	AZ  Message
+0    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fe72:20a2  juju-cbc3a3-0  ubuntu@20.04  	Running
+1    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fec9:3809  juju-cbc3a3-1  ubuntu@20.04  	Running
+2    	started  fd42:7fd9:2c4e:1ff8:216:3eff:fe42:1999  juju-cbc3a3-2  ubuntu@20.04  	Running
+```
+
+Congratulations! Your Charmed Ceph cluster is up and running!
+
+## Cleaning up resources
+
+In case, for any reason, you want to get rid of your Ceph cluster,  you can destroy your model it this way:
+
+`juju destroy-model ceph-model --destroy-storage`
+
+This command will terminate all the virtual machines, containers and resources in our model including [applications](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/application/), which consist of our deployed units.  
+The `--destroy-storage` flag will get rid of the storage device we had commissioned when deploying our units earlier, using the `--storage` flag.
+
+```
+WARNING This command will destroy the "ceph-charms" model and affect the following resources. It cannot be stopped.
+
+ - 3 machines will be destroyed
+  - machine list:
+ - 2 applications will be removed
+  - application list: "ceph-mon" "ceph-osd"
+ - 0 filesystem and 3 volumes will be destroyed
+
+To continue, enter the name of the model to be unregistered: ceph-charms
+Destroying model
+Waiting for model to be removed, 3 machine(s), 2 application(s), 3 volumes......
+Waiting for model to be removed.......
+Model destroyed.
+```
+
+[note type="positive" status="info"]
+The above command only terminates machines/containers and resources for the non-controller model. You may create other models on the controller.
+
+If you wish to destroy the controller, too, and clean up all its resources, run `juju destroy-controller lxd-controller`
+[/note]
+
+## Next steps
+
+You have deployed a Charmed Ceph model on three LXD machines, colocated `ceph-osd` and `ceph-mon` units on them, and integrated the units with Juju.
+
+See our [how-to guides](https://ubuntu.com/ceph/docs/howtos) to find out how you can manage your cluster, and how to achieve specific goals with Charmed Ceph.
+
+Or, explore our [Explanation](https://ubuntu.com/ceph/docs/explanation) and [Reference](https://ubuntu.com/ceph/docs/reference) sections for additional information and quick references.


### PR DESCRIPTION
We have [Charmed Ceph](https://ubuntu.com/ceph/docs) tasks now onboarded in the academy, i.e. #314, #315 and #316, but contributors are not able to edit on Discourse due to insufficient permissions.
This PR adds the content associated with these issues (and more) to allow the contributors to make changes.