### PR TITLE
Update events/index.md

### DIFF
--- a/website/events/index.md
+++ b/website/events/index.md
@@ -6,7 +6,7 @@ All events related to the Documentation Academy can be found in the [Documentati
 
 ## Community Hour
 
-**We host a [Community Hour](https://discourse.ubuntu.com/t/community-hour/42771) every week on a Friday, 16:00 UTC.**
+**We host a [Community Hour](https://discourse.ubuntu.com/t/community-hour/42771) every two weeks on a Friday, 16:00 UTC.**
 
 Our _Community Hour_ sessions are an informal forum for discussions related to documentation.
 


### PR DESCRIPTION
https://documentation.academy/events/ still lists the community hour as being weekly. I updated this to reflect the new bi-weekly schedule as indicated @ https://discourse.ubuntu.com/t/documentation-community-hour/42771 

This may be a minor oversight/discrepancy but my OCD sure caught it. This is my first PR (I hope it's not too tedious).