### PR TITLE
Update LXD docs URLs following domain migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The first words of an issue's title will typically indicate the project it invol
 - [Charmed Ceph](https://ubuntu.com/ceph/docs): a Juju-native way of deploying a Ceph cluster
 - [Charmed OpenStack](https://ubuntu.com/openstack/docs): our traditional enterprise cloud solution
 - [Juju](https://juju.is/docs):  open source orchestration engine
-- [LXD](https://documentation.ubuntu.com/lxd/en/latest/): open source container and VM management at any scale
+- [LXD](https://canonical.com/lxd/docs/latest/): open source container and VM management at any scale
 - [Landscape](https://ubuntu.com/landscape/docs): Ubuntu systems management, monitoring and administration platform
 - [Launchpad](https://documentation.ubuntu.com/launchpad/en/latest/): software development lifecycle and collaboration platform
 - [MAAS](https://maas.io/docs): bare metal cloud with on-demand servers

--- a/charmed-ceph/tutorial.md
+++ b/charmed-ceph/tutorial.md
@@ -53,7 +53,7 @@ juju bootstrap localhost lxd-controller
 Creating Juju controller "lxd-controller" on localhost/localhost
 Looking for packaged Juju agent version 3.6.3 for amd64
 Located Juju agent version 3.6.3-ubuntu-amd64 at https://streams.canonical.com/juju/tools/agent/3.6.3/juju-3.6.3-linux-amd64.tgz
-To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
+To configure your system to better support LXD containers, please see: https://canonical.com/lxd/docs/latest/explanation/performance_tuning/
 Launching controller instance(s) on localhost/localhost...
  - juju-6f74c7-0 (arch=amd64)            	 
 Installing Juju agent on bootstrap instance

--- a/snapcraft/tutorials/create-a-new-snap.md
+++ b/snapcraft/tutorials/create-a-new-snap.md
@@ -61,7 +61,7 @@ LXD can now be initialised with the 'lxd init' command:
 lxd init --minimal
 ```
 
-See [How to install LXD](https://documentation.ubuntu.com/lxd/en/latest/installing/#installing) for further installation options and troubleshooting.
+See [How to install LXD](https://canonical.com/lxd/docs/latest/installing/#installing) for further installation options and troubleshooting.
 
 <h3 id='heading--yaml'>1.2 Create a YAML template</h3>
 


### PR DESCRIPTION
LXD docs are now on https://canonical.com/lxd/docs/