### PR TITLE
docs: fix link, spelling, and other issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The first words of an issue's title will typically indicate the project it invol
 - [Landscape](https://ubuntu.com/landscape/docs): Ubuntu systems management, monitoring and administration platform
 - [Launchpad](https://documentation.ubuntu.com/launchpad/en/latest/): software development lifecycle and collaboration platform
 - [MAAS](https://maas.io/docs): bare metal cloud with on-demand servers
-- [MicroCeph](https://documentation.ubuntu.com/canonical-microceph/stable/): a Ceph orchestration tool; the easiest way to deploy and manage a Ceph cluster
+- [MicroCeph](https://documentation.ubuntu.com/microceph/stable/): a Ceph orchestration tool; the easiest way to deploy and manage a Ceph cluster
 - [MicroStack](https://canonical-openstack.readthedocs-hosted.com/en/latest/): our next generation enterprise cloud solution
 - [Multipass](https://discourse.ubuntu.com/t/multipass-documentation/8294): tool to generate cloud-style Ubuntu virtual machines
 - [Netplan](https://github.com/canonical/netplan): network configuration for various backends

--- a/website/.custom_wordlist.txt
+++ b/website/.custom_wordlist.txt
@@ -41,12 +41,15 @@ golang
 Hackmamba
 howto
 https
+IDEs
 IoT
 JIRA
 KDE
+Krátký
 LaTeX
 LDAP
 lifecycle
+Linters
 MAAS
 makefile
 md
@@ -67,7 +70,7 @@ organize
 Pandoc
 prized
 PRs
-Prioritize 
+Prioritize
 categorizing
 prioritize
 rebase
@@ -76,6 +79,7 @@ recognize
 repo
 repos
 reStructured
+reusability
 Rockcraft
 RST
 rST
@@ -84,6 +88,7 @@ Snapcraft
 specialized
 specializes
 SSL
+stylesheets
 TLS
 UDP
 uniquenesses

--- a/website/docs/howto/become-a-mentor.md
+++ b/website/docs/howto/become-a-mentor.md
@@ -267,6 +267,5 @@ As such, the mentors should recognize significant achievements in the following 
 
 ## Additional resources
 
-- [How to create an issue](https://documentation.academy/docs/howto/create-an-issue/)
 - [Craft a constructive peer review](https://documentation.academy/library/tutorials/craft-a-constructive-peer-review/)
 - [How to implement a peer reviewer's feedback in your documentation](https://documentation.academy/library/reference/how-to-implement-peer-reviewers-feedback/)

--- a/website/docs/howto/become-a-mentor.md
+++ b/website/docs/howto/become-a-mentor.md
@@ -127,8 +127,6 @@ Include how to contact the mentor:
 Please feel free to reach out to the mentor on [Matrix](https://matrix.to/#/@username) if you have further questions.
 ```
 
-There are several examples of the application of this model: [#352](https://github.com/canonical/open-documentation-academy/issues/352)
-
 ### Labels
 
 Make sure to label the issue correctly following the guidelines specified in the CODA repository's [README file](https://github.com/canonical/open-documentation-academy#issue-labels), including the size of the issue.

--- a/website/events/community-hour-discussions/docs-as-code.md
+++ b/website/events/community-hour-discussions/docs-as-code.md
@@ -15,8 +15,7 @@ This presentation was developed with valuable input and feedback from:
 * [Nick Veitch](https://www.linkedin.com/in/nickveitch/)
 
 ---
-
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=AVNfH99KiME" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/AVNfH99KiME" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ---
 
@@ -78,9 +77,9 @@ Integrating documentation with code streamlines ongoing maintenance, for example
 
 #### Tools
 
-Core tooling is typically open source and portable rather than proprietary (for example, instead of Adobe FrameMaker, MadCap, or RoboHelp), which reduces vendor lock-in and makes future tool changes easier.
+Core tooling is typically open source and portable rather than proprietary, which reduces vendor lock-in and makes future tool changes easier.
 
-Because developers are already familiar with these tools—such as IDEs, text editors, and scripting tools—they can contribute to documentation more naturally, strengthening collaboration.
+Because developers are already familiar with these tools—such as Integrated Development Environments (IDEs), text editors, and scripting tools—they can contribute to documentation more naturally, strengthening collaboration.
 
 ### The Negatives
 

--- a/website/events/community-hour-discussions/getting-hired.md
+++ b/website/events/community-hour-discussions/getting-hired.md
@@ -88,4 +88,4 @@ Start preparing and applying now, there is no better time.
 * [Sustain podcast](https://podcast.sustainoss.org/)
 * [Changelog podcast](https://changelog.com/podcast)
 * [University of Oxford Style Guide](https://www.ox.ac.uk/public-affairs/style-guide)
-* [Inclusive Language Guide](https://policy-practice.oxfam.org/resources/inclusive-language-guide-621487/)
+* [Inclusive Language Guide](https://oxfamilibrary.openrepository.com/server/api/core/bitstreams/b84e4514-6044-404a-9136-1c677ed3d518/content)

--- a/website/events/community-hour-discussions/index.md
+++ b/website/events/community-hour-discussions/index.md
@@ -17,6 +17,6 @@ You can also watch the original videos to explore the topics in depth.
 Documenting a new project <documenting-new-project>
 Getting hired as a technical writer <getting-hired>
 Markup languages for documentation <markup-languages>
-Documentation as Code <odh-015-docs-as-code>
+Documentation as Code <docs-as-code>
 
 ```


### PR DESCRIPTION
What I did:
- Fixed spelling issues.
- Updated the broken link about the inclusive language guide.
- Removed the broken link about creating an issue (page was deleted by Anna).
- Modified docs-as-code document name for consistency.
- Fixed the Youtube URL about the docs-as-code video.
- I removed the sentence "There are several examples of the application of this model: [#352](https://github.com/canonical/open-documentation-academy/issues/352)" because I didn't get what it meant. Which model? We also provided only one example there. As we already have the code blocks as examples, I thought that was enough.
- Updated MicroCeph documentation URL.