### PR TITLE
Website: add technical writing review checklist

### DIFF
--- a/website/docs/reference/index.md
+++ b/website/docs/reference/index.md
@@ -4,5 +4,6 @@
 :maxdepth: 1
 
 resources.md
+technical-writing-review-checklist.md
 
 ```

--- a/website/docs/reference/technical-writing-review-checklist.md
+++ b/website/docs/reference/technical-writing-review-checklist.md
@@ -63,11 +63,11 @@ templates or conventions.
 - Informative images have concise alternative text.
 - Complex diagrams have an adjacent description of their essential
   information.
-- Color is not the only way that information or state is communicated.
+- Colour is not the only way that information or state is communicated.
 - Text and essential graphical elements meet the project's contrast
   requirements.
-- Language avoids stereotypes, unnecessary gendering, and exclusionary
-  assumptions.
+- Language avoids stereotypes, unnecessary references to gender, and
+  exclusionary assumptions.
 
 ## Code, commands, and media
 

--- a/website/docs/reference/technical-writing-review-checklist.md
+++ b/website/docs/reference/technical-writing-review-checklist.md
@@ -1,0 +1,94 @@
+# Technical writing review checklist
+
+Use this checklist to review your own work or another writer's work. Apply the
+items that are relevant to the document type and follow any project-specific
+templates or conventions.
+
+## Purpose and audience
+
+- The document has a clear goal.
+- The intended audience and its assumed knowledge are identifiable.
+- The document type matches the user's need: learning, completing a task,
+  understanding a topic, or finding factual information.
+- The scope is clear, and unrelated information is excluded or linked.
+
+## Completeness
+
+- Prerequisites and required permissions are stated.
+- Tutorials and how-to guides include every step needed to reach the stated
+  outcome.
+- Installation instructions include verification and removal or rollback
+  guidance when users are likely to need it.
+- Expected results, limitations, and relevant next steps are included.
+- Terms are defined at first use or linked to an authoritative definition.
+
+## Accuracy
+
+- Commands, code samples, procedures, and examples have been tested.
+- Product names, option names, version numbers, and default values are
+  correct.
+- Claims are supported by primary documentation or reputable sources.
+- Links lead to the intended current content.
+- Warnings describe the consequence and appear before the risky action.
+
+## Structure and navigation
+
+- Content follows a logical order for the document type.
+- Headings describe their sections and use a consistent hierarchy.
+- Paragraphs and sections focus on one subject.
+- Lists and tables make information easier to scan rather than more complex.
+- Link text describes its destination without relying on phrases such as
+  "click here" or a bare URL.
+
+## Clarity and conciseness
+
+- Language is appropriate for the audience and avoids unexplained jargon.
+- Sentences use active voice where it makes the actor and action clearer.
+- Instructions state the action before its result or supporting detail.
+- Examples are relevant and add information that the surrounding text does
+  not already provide.
+- Repeated, filler, and obsolete content has been removed.
+
+## Style and consistency
+
+- The project's style guide and template are followed.
+- Terminology, capitalization, punctuation, and spelling are consistent.
+- Headings use sentence case and do not skip levels.
+- The tone is consistent with related documentation.
+- The document uses one English spelling convention consistently.
+
+## Accessibility
+
+- Heading order, lists, and tables preserve a meaningful reading order.
+- Informative images have concise alternative text.
+- Complex diagrams have an adjacent description of their essential
+  information.
+- Color is not the only way that information or state is communicated.
+- Text and essential graphical elements meet the project's contrast
+  requirements.
+- Language avoids stereotypes, unnecessary gendering, and exclusionary
+  assumptions.
+
+## Code, commands, and media
+
+- Code blocks identify their language and separate commands from output.
+- Commands can be copied without prompt characters or unrelated comments.
+- Placeholders are clearly identified and used consistently.
+- Screenshots and videos are used only when text cannot communicate the
+  information effectively.
+- Images are legible at the size at which they are displayed.
+
+## Maintainability
+
+- Time-sensitive statements explain which version or date they apply to.
+- Links use stable or permanent targets where possible.
+- Examples avoid unnecessary values that will require frequent updates.
+- New content does not duplicate an authoritative page that could be linked
+  instead.
+- Adding, moving, or removing the page leaves the documentation navigation
+  coherent.
+
+## Related resources
+
+- [Canonical documentation style guide](https://documentation.ubuntu.com/style-guide/)
+- [Diataxis reference guidance](https://diataxis.fr/reference/)


### PR DESCRIPTION
Closes #353.

## Summary

- add a technical writing review checklist to the website reference section
- cover purpose, completeness, accuracy, structure, clarity, consistency, accessibility, media, and maintainability
- add the new page to the reference navigation
- link to the Canonical documentation style guide and Diataxis reference guidance

## Checks

- `make html`: passed with warnings treated as errors
- `make spellcheck`: passed with the `en_GB` dictionary
- both links added by this change return HTTP 200
- `git diff --check origin/main...HEAD`: passed
- Gitleaks v8.30.1 over `origin/main..HEAD`: no leaks found

`make linkcheck` reaches both links added by this change, but the complete local run exits non-zero on an existing link outside this diff: `https://www.gnutls.org/` in `docs/explanation/glossary_what.md:74` returns a TLS hostname mismatch. The latest `main` documentation workflow is green.
