### PR TITLE
CODA website: AI guide title change

### DIFF
--- a/website/docs/howto/index.md
+++ b/website/docs/howto/index.md
@@ -6,5 +6,5 @@
 Get started <get-started/index>
 Work on a task <work-on-an-issue>
 Become a mentor <become-a-mentor>
-AI guide <ai-guide>
+Use AI to contribute <use-ai-to-contribute>
 ```

--- a/website/docs/howto/use-ai-to-contribute.md
+++ b/website/docs/howto/use-ai-to-contribute.md
@@ -1,4 +1,4 @@
-# Using AI for CODA tasks
+# How to use AI to contribute
 Canonical’s Open Documentation Academy (CODA) is a place for people to discover open source through documentation contributions. This guide explains how we think about Artificial Intelligence (AI) in the context of CODA contributions and how you can use AI tools as a contributor.
 
 ## Why it matters


### PR DESCRIPTION
Title and name of the AI guide in the navigation menu were changed for consistency. 