### PR TITLE
docs: improve mentor handbook introduction

### DIFF
--- a/website/docs/howto/become-a-mentor.md
+++ b/website/docs/howto/become-a-mentor.md
@@ -1,6 +1,6 @@
 # CODA mentor handbook
 
-A guide for participants interested in creating issues and mentoring contributors in Canonical's Open Documentation Academy (CODA).
+Use this handbook to create documentation tasks for the Open Documentation Academy (CODA) and mentor contributors through to completion. It explains how to create and scope suitable issues, guide contributors through their work, and provide feedback as they complete their tasks.
 
 ## Creating issues
 


### PR DESCRIPTION
**Improve the introduction to the CODA mentor handbook.**

The introduction now explains the purpose of the handbook,
who it is for and what it covers.

Closes #387